### PR TITLE
Fix National Foundation Day name of japanese

### DIFF
--- a/jp.yaml
+++ b/jp.yaml
@@ -37,7 +37,7 @@ months:
     mday: 1
     function: jp_substitute_holiday(year, month, day)
   2:
-  - name: 建国記念日
+  - name: 建国記念の日
     regions: [jp]
     mday: 11
   - name: 振替休日
@@ -255,7 +255,7 @@ methods:
 tests: |
   {Date.civil(2008,1,1) => '元日',
    Date.civil(2010,1,11) => '成人の日',
-   Date.civil(2008,2,11) => '建国記念日',
+   Date.civil(2008,2,11) => '建国記念の日',
    Date.civil(2008,4,29) => '昭和の日',
    Date.civil(2008,5,3) => '憲法記念日',
    Date.civil(2008,5,5) => 'こどもの日',


### PR DESCRIPTION
The exact name will contain the word "の".

see:
- [Wikipedia](https://en.wikipedia.org/wiki/National_Foundation_Day)
- [government link](http://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html#hourutsu)