### PR TITLE
Add observed days for canadian national holidays

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -22,6 +22,7 @@ months:
   - name: New Year's Day
     regions: [ca]
     mday: 1
+    observed: to_monday_if_weekend(date)
   - name: New Year's
     regions: [ca_qc]
     mday: 2
@@ -93,7 +94,7 @@ months:
   - name: Canada Day
     regions: [ca]
     mday: 1
-    observed: to_monday_if_sunday(date)
+    observed: to_monday_if_weekend(date)
   - name: Orangemen's Day
     regions: [ca_nf]
     mday: 12
@@ -143,13 +144,16 @@ months:
   - name: Remembrance Day
     regions: [ ca_ab, ca_sk, ca_bc, ca_pe, ca_nf, ca_nt, ca_nu, ca_nb, ca_yk]
     mday: 11
+    observed: to_monday_if_weekend(date)
   12:
   - name: Christmas Day
     regions: [ca]
     mday: 25
+    observed: to_monday_if_weekend(date)
   - name: Boxing Day
     regions: [ca]
     mday: 26
+    observed: to_weekday_if_boxing_weekend(date)
 methods:
   ca_victoria_day:
     # Monday on or before May 24
@@ -314,4 +318,30 @@ tests: |
       :ca_yk
     ].each do |province|
       assert_equal "Remembrance Day", Holidays.on(Date.civil(2016,11,11), province)[0][:name]
+    end
+
+    # New years observed date
+    [Date.civil(2011, 1, 3), Date.civil(2012, 1, 2), Date.civil(2016, 1, 1)].each do |date|
+      assert_equal 'New Year\'s Day', Holidays.on(date, :ca, :observed)[0][:name]
+    end
+
+    # Canada Day observed date
+    [Date.civil(2011, 7, 1), Date.civil(2012, 7, 2), Date.civil(2017, 7, 3)].each do |date|
+      assert_equal 'Canada Day', Holidays.on(date, :ca, :observed)[0][:name]
+    end
+
+    # Remembrance Day observed date
+    [Date.civil(2010, 11, 11), Date.civil(2012, 11, 12), Date.civil(2017, 11, 13)].each do |date|
+      assert_equal 'Remembrance Day', Holidays.on(date, :ca, :observed)[0][:name]
+    end
+
+    # Christmas observed date
+    [Date.civil(2010, 12, 27), Date.civil(2012, 12, 25), Date.civil(2016, 12, 26)].each do |date|
+      assert_equal 'Christmas Day', Holidays.on(date, :ca, :observed)[0][:name]
+    end
+
+    # Boxing Day observed date
+    [Date.civil(2010, 12, 28), Date.civil(2012, 12, 26), Date.civil(2016, 12, 27),
+     Date.civil(2015, 12, 28)].each do |date|
+      assert_equal 'Boxing Day', Holidays.on(date, :ca, :observed)[0][:name]
     end


### PR DESCRIPTION
Hello! This PR adds the observed days Canadian national holidays. It seems that the general rule for Canada is to always observe the holidays on the following Monday if the actual holiday falls on the weekend. If Christmas falls on a weekend, it is observed on Monday and Boxing day is observed on Tuesday.

Sources:
 - http://www.bankofcanada.ca/about/contact-information/bank-of-canada-holiday-schedule/. 
 - http://www.tpsgc-pwgsc.gc.ca/remuneration-compensation/paye-centre-pay/feries-holidays-eng.html

@ptrimble for review