### PR TITLE
Add defaults for Christmas and Boxing day for AU

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -5,7 +5,7 @@
 # - http://www.docep.wa.gov.au/lr/LabourRelations/Content/Wages%20and%20Conditions/Public%20Holidays/Public_Holidays.html
 # - http://www.wst.tas.gov.au/employment_info/public_holidays
 # - https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays
---- 
+---
 months:
   0:
   - name: Good Friday
@@ -144,7 +144,7 @@ months:
     wday: 2
   12:
   - name: Christmas Day # CHRISTMAS DAY - ACT, NSW, QLD, Tas, WA observe on 27th (and 25th) if 25th is a Sunday
-    regions: [au_qld, au_nsw, au_act, au_tas, au_wa]
+    regions: [au, au_qld, au_nsw, au_act, au_tas, au_wa]
     mday: 25
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
   - name: Christmas Day # CHRISTMAS DAY - SA observes on 26th if 25th is a Sunday (Boxing Day goes to 27th)
@@ -155,7 +155,7 @@ months:
     regions: [au_vic, au_nt]
     function: xmas_to_weekday_if_weekend(year)
   - name: Boxing Day
-    regions: [au_nsw, au_vic, au_qld, au_act, au_wa]
+    regions: [au, au_nsw, au_vic, au_qld, au_act, au_wa]
     mday: 26
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
   - name: Boxing Day
@@ -332,6 +332,8 @@ tests: |
     assert_equal "ANZAC Day", Date.civil(2015, 4, 27).holidays(:au_wa, :observed)[0][:name]
 
     # BOXING DAY - QLD observes weekend and monday
+    assert_equal "Boxing Day", Date.civil(2015, 12, 26).holidays(:au[0][:name]
+    assert_equal "Boxing Day", Date.civil(2015, 12, 28).holidays(:au, :observed)[0][:name]
     assert_equal "Boxing Day", Date.civil(2015, 12, 26).holidays(:au_qld)[0][:name]
     assert_equal "Boxing Day", Date.civil(2015, 12, 28).holidays(:au_qld, :observed)[0][:name]
 
@@ -353,6 +355,8 @@ tests: |
     assert_equal 'Royal Hobart Regatta', Holidays.on(Date.civil(2016, 2, 8), :au_tas_south)[0][:name]
 
     # CHRISTMAS DAY - ACT, NSW, QLD, Tas, WA observe on 27th (and 25th) if 25th is a Sunday
+    assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au, :observed)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au_qld)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_qld, :observed)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au_nsw)[0][:name]


### PR DESCRIPTION
With the current Australian holiday definitions, there is no country wide default for Christmas or Boxing day. You need to specify the state even though Christmas and Boxing Day are national holidays, even if the rules if when they are observed are slightly different.

Currently if I run `Holidays.on(Date.civil(2016, 12, 25), :au)` I get empty array back. The goal of this PR is to add `au` to the definition used by most Australian states.

Source: http://www.australia.gov.au/about-australia/special-dates-and-events/public-holidays

@ptrimble