### PR TITLE
changes de yml to better reflect regions

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -1,13 +1,10 @@
 # German holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2016-03-16
+# Updated: 2016-11-27
 #
-# Changes 2016-03-16:
-# - Add Ostersonntag, Pfingstsonntag, Heilig Abend and Silvester as informal holidays.
-# - Add Fronleichnam for de_sn_aux, de_th_aux
-# - Add Reformationstag as informal holiday for de_bw (it is school free)
-# - Add Reformationstag for 2017 (500 years)
-# - Correction in test for :de_by_aux
+# Changes 2016-11-27:
+# - Change de_sn_aux, de_th_aux to de_sn_bz (Bautzen) and de_th_eic (Eichsfeld), to reflect region
+# - Change de_sn_aux to de_by_a to reflect only Augsburg
 #
 # Sources:
 # - http://en.wikipedia.org/wiki/Holidays_in_Germany
@@ -46,7 +43,7 @@ months:
     function: easter(year)
     function_modifier: 60
   - name: Fronleichnam
-    regions: [de_sn_aux, de_th_aux]
+    regions: [de_sn_bz, de_th_eic]
     function: easter(year)
     function_modifier: 60
   - name: Weiberfastnacht
@@ -80,7 +77,7 @@ months:
     regions: [de_by, de_sl]
     mday: 15
   - name: Friedensfest
-    regions: [de_by_aux]
+    regions: [de_by_a]
     mday: 8
   10:
   - name: Tag der Deutschen Einheit
@@ -155,7 +152,7 @@ tests: |
       assert_equal 'Heilige Drei Könige', Holidays.on(Date.civil(2009,1,6), r)[0][:name]
     end
 
-    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_].each do |r|
+    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_sn_bz, de_th_eic, :de_].each do |r|
       assert_equal 'Fronleichnam', Holidays.on(Date.civil(2009,6,11), r)[0][:name]
     end
 
@@ -181,7 +178,7 @@ tests: |
       assert_equal 'Allerheiligen', Holidays.on(Date.civil(2009,11,1), r)[0][:name]
     end
 
-    [:de_by_aux].each do |r|
+    [:de_by_a].each do |r|
       assert_equal 'Friedensfest', Holidays.on(Date.civil(2015,8,8),r)[0][:name]
     end
 

--- a/de.yaml
+++ b/de.yaml
@@ -3,8 +3,8 @@
 # Updated: 2016-11-27
 #
 # Changes 2016-11-27:
-# - Change de_sn_aux, de_th_aux to de_sn_bz (Bautzen) and de_th_eic (Eichsfeld), to reflect region
-# - Change de_sn_aux to de_by_a to reflect only Augsburg
+# - Change de_sn_aux, de_th_aux to de_sn_sorbian (because it only is celebrated in Sorbian regions in Sachsen) and de_th_eichsfeld, to reflect region of Eichsfeld
+# - Change de_sn_aux to de_by_augsburg to reflect only City of Augsburg
 #
 # Sources:
 # - http://en.wikipedia.org/wiki/Holidays_in_Germany
@@ -43,7 +43,7 @@ months:
     function: easter(year)
     function_modifier: 60
   - name: Fronleichnam
-    regions: [de_sn_bz, de_th_eic]
+    regions: [de_sn_sorbian, de_th_eichsfeld]
     function: easter(year)
     function_modifier: 60
   - name: Weiberfastnacht
@@ -77,7 +77,7 @@ months:
     regions: [de_by, de_sl]
     mday: 15
   - name: Friedensfest
-    regions: [de_by_a]
+    regions: [de_by_augsburg]
     mday: 8
   10:
   - name: Tag der Deutschen Einheit
@@ -152,7 +152,7 @@ tests: |
       assert_equal 'Heilige Drei Könige', Holidays.on(Date.civil(2009,1,6), r)[0][:name]
     end
 
-    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_sn_bz, de_th_eic, :de_].each do |r|
+    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_sn_sorbian, de_th_eichsfeld, :de_].each do |r|
       assert_equal 'Fronleichnam', Holidays.on(Date.civil(2009,6,11), r)[0][:name]
     end
 
@@ -178,7 +178,7 @@ tests: |
       assert_equal 'Allerheiligen', Holidays.on(Date.civil(2009,11,1), r)[0][:name]
     end
 
-    [:de_by_a].each do |r|
+    [:de_by_augsburg].each do |r|
       assert_equal 'Friedensfest', Holidays.on(Date.civil(2015,8,8),r)[0][:name]
     end
 


### PR DESCRIPTION
used car license plate abbreviations to reflect the regions where a
holiday is celebrated

Sorry, this doesn't fix the problem with missing holidays on de_by_a AKA de_by_aux, I'm still investigating.