### PR TITLE
Updates for AU & Philippines holidays

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -143,27 +143,24 @@ months:
     week: 1
     wday: 2
   12:
-  - name: Christmas Day # CHRISTMAS DAY - ACT, NSW, QLD, Tas, WA observe on 27th (and 25th) if 25th is a Sunday
-    regions: [au_qld, au_nsw, au_act, au_tas, au_wa]
+  - name: Christmas Day # CHRISTMAS DAY - All states except SA observe on 27th (and 25th) if 25th is a Sunday
+    regions: [au_qld, au_nsw, au_act, au_tas, au_wa, au_vic, au_nt]
     mday: 25
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
-  - name: Christmas Day # CHRISTMAS DAY - SA observes on 26th if 25th is a Sunday (Boxing Day goes to 27th)
-    regions: [au_sa]
-    mday: 25
-    observed: to_monday_if_weekend(date)
-  - name: Christmas Day # CHRISTMAS DAY - Victoria and NT don't observe 25th if weekend - xmas is on the 27th
-    regions: [au_vic, au_nt]
-    function: xmas_to_weekday_if_weekend(year)
   - name: Boxing Day
     regions: [au_nsw, au_vic, au_qld, au_act, au_wa]
     mday: 26
     observed: to_tuesday_if_sunday_or_monday_if_saturday(date)
   - name: Boxing Day
-    regions: [au_sa]
-    function: to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)
-  - name: Boxing Day
     regions: [au_tas, au_nt]
     function: to_weekday_if_boxing_weekend_from_year(year)
+  - name: Boxing Day
+    regions: [au_sa]
+    function: to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)
+  - name: Christmas Day # CHRISTMAS DAY - SA observes on 26th if 25th is a Sunday (Boxing Day goes to 27th)
+    regions: [au_sa]
+    mday: 25
+    observed: to_monday_if_weekend(date)
 
 methods:
   afl_grand_final:
@@ -369,10 +366,17 @@ tests: |
     assert_equal "Christmas Day", Date.civil(2016, 12, 26).holidays(:au_sa, :observed)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 27).holidays(:au_sa)[0][:name]
 
-    # CHRISTMAS DAY - Victoria and NT don't observe 25th if weekend - xmas is on the 27th
-    assert_nil Date.civil(2016, 12, 25).holidays(:au_vic)[0]
-    assert_nil Date.civil(2016, 12, 25).holidays(:au_nt)[0]
+    # CHRISTMAS DAY - Victoria and NT now observe both 25th and 27th if weekend
+    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_vic)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_nt)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt)[0][:name]
+
+    # NEW YEAR'S DAY - observed on both 1st and 2nd of Jan for 2017
+    regions = {:au_qld, :au_nsw, :au_act, :au_vic, :au_tas, :au_sa, :au_wa, :au_nt}
+    regions.each do |r|
+      assert_equal "New Year's Day", Date.civil(2017, 1, 1).holidays(r)[0][:name]
+      assert_equal "New Year's Day", Date.civil(2017, 1, 2).holidays(r, :observed)[0][:name]
+    end

--- a/au.yaml
+++ b/au.yaml
@@ -5,7 +5,7 @@
 # - http://www.docep.wa.gov.au/lr/LabourRelations/Content/Wages%20and%20Conditions/Public%20Holidays/Public_Holidays.html
 # - http://www.wst.tas.gov.au/employment_info/public_holidays
 # - https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays
----
+--- 
 months:
   0:
   - name: Good Friday
@@ -140,10 +140,8 @@ months:
     week: 1
   - name: Melbourne Cup Day
     regions: [au_vic_melbourne]
-    function: melbourne_cup_day_melbourne_only(year)
-  - name: Melbourne Cup Day
-    regions: [au_vic, au_vic_melbourne]
-    function: melbourne_cup_day_all_vic(year)
+    week: 1
+    wday: 2
   12:
   - name: Christmas Day # CHRISTMAS DAY - ACT, NSW, QLD, Tas, WA observe on 27th (and 25th) if 25th is a Sunday
     regions: [au_qld, au_nsw, au_act, au_tas, au_wa]
@@ -168,18 +166,6 @@ months:
     function: to_weekday_if_boxing_weekend_from_year(year)
 
 methods:
-  melbourne_cup_day_melbourne_only:
-    arguments: year
-    source: |
-      if year <= 2015
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 11, :first, :tuesday)
-      end
-  melbourne_cup_day_all_vic:
-    arguments: year
-    source: |
-      if year >= 2016
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 11, :first, :tuesday)
-      end
   afl_grand_final:
     arguments: year
     source: |
@@ -327,11 +313,6 @@ tests: |
 
     assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2014,11,4), :au_vic_melbourne)[0][:name]
     assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2015,11,3), :au_vic_melbourne)[0][:name]
-
-    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2016,11,1), :au_vic)[0][:name]
-    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2017,11,7), :au_vic)[0][:name]
-    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2016,11,1), :au_vic_melbourne)[0][:name]
-    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2017,11,7), :au_vic_melbourne)[0][:name]
 
     assert_equal 'Friday before the AFL Grand Final', Date.civil(2015,10,2).holidays(:au_vic)[0][:name]
     assert_equal 'Friday before the AFL Grand Final', Date.civil(2016,9, 30).holidays(:au_vic)[0][:name]

--- a/au.yaml
+++ b/au.yaml
@@ -375,7 +375,7 @@ tests: |
     assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt)[0][:name]
 
     # NEW YEAR'S DAY - observed on both 1st and 2nd of Jan for 2017
-    regions = {:au_qld, :au_nsw, :au_act, :au_vic, :au_tas, :au_sa, :au_wa, :au_nt}
+    regions = [:au_qld, :au_nsw, :au_act, :au_vic, :au_tas, :au_sa, :au_wa, :au_nt]
     regions.each do |r|
       assert_equal "New Year's Day", Date.civil(2017, 1, 1).holidays(r)[0][:name]
       assert_equal "New Year's Day", Date.civil(2017, 1, 2).holidays(r, :observed)[0][:name]

--- a/au.yaml
+++ b/au.yaml
@@ -5,7 +5,7 @@
 # - http://www.docep.wa.gov.au/lr/LabourRelations/Content/Wages%20and%20Conditions/Public%20Holidays/Public_Holidays.html
 # - http://www.wst.tas.gov.au/employment_info/public_holidays
 # - https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays
---- 
+---
 months:
   0:
   - name: Good Friday
@@ -371,8 +371,8 @@ tests: |
     assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au_nt)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_vic)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_nt)[0][:name]
-    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic)[0][:name]
-    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic, :observed)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt, :observed)[0][:name]
 
     # NEW YEAR'S DAY - observed on both 1st and 2nd of Jan for 2017
     regions = [:au_qld, :au_nsw, :au_act, :au_vic, :au_tas, :au_sa, :au_wa, :au_nt]

--- a/au.yaml
+++ b/au.yaml
@@ -170,7 +170,9 @@ methods:
       when 2015
         Date.civil(2015, 10, 2)
       when 2016
-        Date.civil(2017, 9, 30)
+        Date.civil(2016, 9, 30)
+      when 2017
+        Date.civil(2017, 9, 29)
       end
   qld_queens_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
@@ -312,7 +314,8 @@ tests: |
     assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2015,11,3), :au_vic_melbourne)[0][:name]
 
     assert_equal 'Friday before the AFL Grand Final', Date.civil(2015,10,2).holidays(:au_vic)[0][:name]
-    assert_equal 'Friday before the AFL Grand Final', Date.civil(2016,9, 30).holidays(:au_vic)[0][:name]
+    assert_equal 'Friday before the AFL Grand Final', Date.civil(2016,9,30).holidays(:au_vic)[0][:name]
+    assert_equal 'Friday before the AFL Grand Final', Date.civil(2017,9,29).holidays(:au_vic)[0][:name]
 
     assert_equal "May Public Holiday", Date.civil(2005, 5, 16).holidays(:au_sa)[0][:name]
     assert_equal [], Date.civil(2014, 5, 19).holidays(:au_sa)

--- a/au.yaml
+++ b/au.yaml
@@ -5,7 +5,7 @@
 # - http://www.docep.wa.gov.au/lr/LabourRelations/Content/Wages%20and%20Conditions/Public%20Holidays/Public_Holidays.html
 # - http://www.wst.tas.gov.au/employment_info/public_holidays
 # - https://www.fairwork.gov.au/leave/public-holidays/list-of-public-holidays
---- 
+---
 months:
   0:
   - name: Good Friday
@@ -140,8 +140,10 @@ months:
     week: 1
   - name: Melbourne Cup Day
     regions: [au_vic_melbourne]
-    week: 1
-    wday: 2
+    function: melbourne_cup_day_melbourne_only(year)
+  - name: Melbourne Cup Day
+    regions: [au_vic, au_vic_melbourne]
+    function: melbourne_cup_day_all_vic(year)
   12:
   - name: Christmas Day # CHRISTMAS DAY - ACT, NSW, QLD, Tas, WA observe on 27th (and 25th) if 25th is a Sunday
     regions: [au_qld, au_nsw, au_act, au_tas, au_wa]
@@ -166,6 +168,18 @@ months:
     function: to_weekday_if_boxing_weekend_from_year(year)
 
 methods:
+  melbourne_cup_day_melbourne_only:
+    arguments: year
+    source: |
+      if year <= 2015
+        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 11, :first, :tuesday)
+      end
+  melbourne_cup_day_all_vic:
+    arguments: year
+    source: |
+      if year >= 2016
+        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 11, :first, :tuesday)
+      end
   afl_grand_final:
     arguments: year
     source: |
@@ -313,6 +327,11 @@ tests: |
 
     assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2014,11,4), :au_vic_melbourne)[0][:name]
     assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2015,11,3), :au_vic_melbourne)[0][:name]
+
+    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2016,11,1), :au_vic)[0][:name]
+    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2017,11,7), :au_vic)[0][:name]
+    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2016,11,1), :au_vic_melbourne)[0][:name]
+    assert_equal 'Melbourne Cup Day', Holidays.on(Date.civil(2017,11,7), :au_vic_melbourne)[0][:name]
 
     assert_equal 'Friday before the AFL Grand Final', Date.civil(2015,10,2).holidays(:au_vic)[0][:name]
     assert_equal 'Friday before the AFL Grand Final', Date.civil(2016,9, 30).holidays(:au_vic)[0][:name]

--- a/au.yaml
+++ b/au.yaml
@@ -367,8 +367,8 @@ tests: |
     assert_equal "Boxing Day", Date.civil(2016, 12, 27).holidays(:au_sa)[0][:name]
 
     # CHRISTMAS DAY - Victoria and NT now observe both 25th and 27th if weekend
-    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic)[0][:name]
-    assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_nt)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au_vic)[0][:name]
+    assert_equal "Christmas Day", Date.civil(2016, 12, 25).holidays(:au_nt)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_vic)[0][:name]
     assert_equal "Boxing Day", Date.civil(2016, 12, 26).holidays(:au_nt)[0][:name]
     assert_equal "Christmas Day", Date.civil(2016, 12, 27).holidays(:au_vic)[0][:name]

--- a/de.yaml
+++ b/de.yaml
@@ -152,7 +152,7 @@ tests: |
       assert_equal 'Heilige Drei Könige', Holidays.on(Date.civil(2009,1,6), r)[0][:name]
     end
 
-    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_sn_sorbian, de_th_eichsfeld, :de_].each do |r|
+    [:de_bw, :de_by, :de_he, :de_nw, :de_rp, :de_sl, :de_sn_sorbian, :de_th_eichsfeld, :de_].each do |r|
       assert_equal 'Fronleichnam', Holidays.on(Date.civil(2009,6,11), r)[0][:name]
     end
 

--- a/ph.yaml
+++ b/ph.yaml
@@ -26,10 +26,6 @@ months:
   - name: New Year’s Day
     regions: [ph]
     mday: 1
-  2:
-  - name: People Power Anniversary
-    regions: [ph]
-    mday: 25
   4:
   - name: The Day of Valor
     regions: [ph]
@@ -50,9 +46,6 @@ months:
     regions: [ph]
     function: ph_heroes_day(year)
   11:
-  - name: All Saints Day
-    regions: [ph]
-    mday: 1
   - name: Bonifacio Day
     regions: [ph]
     mday: 30
@@ -79,14 +72,12 @@ methods:
 
       date
 tests: |
-    {Date.civil(2015,2,25) => 'People Power Anniversary',
-     Date.civil(2015,4,3) => 'Good Friday',
+    {Date.civil(2015,4,3) => 'Good Friday',
      Date.civil(2015,4,9) => 'The Day of Valor',
      Date.civil(2015,5,1) => 'Labor Day',
      Date.civil(2015,6,12) => 'Independence Day',
      Date.civil(2015,8,21) => 'Ninoy Aquino Day',
      Date.civil(2015,8,31) => 'National Heroes Day',
-     Date.civil(2015,11,1) => 'All Saints Day',
      Date.civil(2015,11,30) => 'Bonifacio Day',
      Date.civil(2015,12,25) => 'Christmas Day',
      Date.civil(2015,12,30) => 'Rizal Day'}.each do |date, name|

--- a/ph.yaml
+++ b/ph.yaml
@@ -26,6 +26,11 @@ months:
   - name: New Year’s Day
     regions: [ph]
     mday: 1
+  2:
+  - name: People Power Anniversary
+    regions: [ph]
+    mday: 25
+    type: informal
   4:
   - name: The Day of Valor
     regions: [ph]
@@ -46,6 +51,10 @@ months:
     regions: [ph]
     function: ph_heroes_day(year)
   11:
+  - name: All Saints Day
+    regions: [ph]
+    mday: 1
+    type: informal
   - name: Bonifacio Day
     regions: [ph]
     mday: 30


### PR DESCRIPTION
Australia: Vic & NT have changed how christmas related holidays are defined, see https://nt.gov.au/employ/for-employees-in-nt/nt-public-holidays http://www.gazette.vic.gov.au/gazette/Gazettes2016/GG2016S364.pdf http://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays

Australia: Fix AFL grand final bug raised at https://github.com/holidays/holidays/issues/252#issuecomment-267761775

Philippines: convert some dates that are "special days" to `informal`, my understanding is that these are days in which not everyone works but are not formally treated as public holidays. see http://www.gov.ph/2015/08/20/proclamation-no-1105-s-2015/

Germany: fix a typo in a test