### PR TITLE
Remove failing vi test

### DIFF
--- a/vi.yaml
+++ b/vi.yaml
@@ -30,7 +30,6 @@ tests: |
      Date.civil(2014,4,30) => 'Ngày Giải phóng miền Nam, thống nhất đất nước',
      Date.civil(2014,5,1) => "Ngày Quốc tế Lao động",
      Date.civil(2014,9,2) => 'Quốc khánh',
-     Date.civil(2017,4,6) => "Giỗ tổ Hùng Vương",
-     Date.civil(2018,3,27) => "Giỗ tổ Hùng Vương"}.each do |date, name|
+     Date.civil(2017,4,6) => "Giỗ tổ Hùng Vương"}.each do |date, name|
       assert_equal name, (Holidays.on(date, :vi)[0] || {})[:name]
     end


### PR DESCRIPTION
Hey @jonathanpike and @ghiculescu! I was getting ready to release v5.5.0 with the updated definitions when I noticed that a specific test in the `vi` defs was failing, specifically:

```ruby
Date.civil(2018,3,27) => 'Giỗ tổ Hùng Vương',
```

I noticed you two talking about it in the other repo. Can we confirm that this is a valid holiday for this region? If so then we have a problem as the gem is not finding it and we'll need to investigate it.

I put up this PR so we could talk. We don't have to merge it if the fix needs to take place over in the ruby repo.