### PR TITLE
Fix observed New Year's day for NYSE

### DIFF
--- a/nyse.yaml
+++ b/nyse.yaml
@@ -4,6 +4,9 @@
 # Source: http://www.nyse.com/about/newsevents/1176373643795.html#earlyclose2008
 #
 # Updated 2008-11-19.
+#
+# Source: https://www.nyse.com/markets/hours-calendars
+# Updated 2017-03-14 By Vassilios Liatsos
 ---
 months:
   0:
@@ -15,6 +18,7 @@ months:
   - name: New Year's Day
     regions: [nyse]
     mday: 1
+    observed: to_monday_if_sunday(date)
   - name: Martin Luther King, Jr. Day
     week: 3
     regions: [nyse]
@@ -61,4 +65,9 @@ tests: |
      Date.civil(2008,11,27) => 'Thanksgiving',
      Date.civil(2008,12,25) => 'Christmas Day'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :nyse)[0] || {})[:name]
+    end
+
+    # Test observed New Year
+    [Date.civil(2017,1,2), Date.civil(2012,1,2), Date.civil(2011,1,1), Date.civil(2006,1,2)].each do |date|
+      assert_equal 'New Year\'s Day', (Holidays.on(date, :nyse, :observed)[0] || {})[:name]
     end


### PR DESCRIPTION
NYSE observes the following Monday if the New Year's Day falls on a Sunday.
This is what happened on January 2017: the observed date was Monday, January 2nd

References:
https://www.nyse.com/markets/hours-calendars
http://nyserules.nyse.com/nyse/rules/nyse-rules/chp_1_3/chp_1_3_3/default.asp


Signed-off-by: Vassilios Liatsos <vassilis@tradelegs.com>