### PR TITLE
Remove incorrect au test for NYD

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -259,8 +259,7 @@ methods:
       end
 
 tests: |
-    {Date.civil(2007,1,1) => 'New Year\'s Day',
-     Date.civil(2007,1,26) => 'Australia Day',
+    {Date.civil(2007,1,26) => 'Australia Day',
      Date.civil(2007,4,6) => 'Good Friday',
      Date.civil(2007,4,9) => 'Easter Monday',
      Date.civil(2007,4,25) => 'ANZAC Day'}.each do |date, name|


### PR DESCRIPTION
Hey @ghiculescu and @adamlyons2! While getting ready for v5.5.0 I noticed a failing `:au` test. You can see what I am removing in this PR.

I remember this specific issue and I remember that I have bounced back and forth on it. The issue here is that we technically cannot/should not have a 'global' `:au` NYD test as things are different depending on the region. But this means if someone asks for `Holidays.on(Date.civil(2007, 1, 1), :au)` they will get back nothing, since TECHNICALLY all of `:au` doesn't celebrate things the same. But that can leave a weird taste in people's mouths.

So what do you think? You are both from Australia (I'm pretty sure) so what would make the most sense to you? Should we just remove the test? Or should we add back in a `:au` NYD holiday so the above call returns the holiday?

Here is the commit that changed things: https://github.com/holidays/definitions/commit/8d5b2eabe813de5cd9524874b6a5f18fd79dd41f