### PR TITLE
Add region specification to lunar_to_solar call

### DIFF
--- a/kr.yaml
+++ b/kr.yaml
@@ -11,7 +11,7 @@ months:
   1:
   - name: Korean New Year
     regions: [kr]
-    function: lunar_to_solar(year, month, day)
+    function: lunar_to_solar(year, month, day, :ko)
     mday: 1
   - name: New Year's Day
     regions: [kr]
@@ -23,7 +23,7 @@ months:
   4:
   - name: Buddah's Birthday
     regions: [kr]
-    function: lunar_to_solar(year, month, day)
+    function: lunar_to_solar(year, month, day, :ko)
     mday: 8
   5:
   - name: Children's Day
@@ -41,7 +41,7 @@ months:
   8:
   - name: Korean Thanksgiving
     regions: [kr]
-    function: lunar_to_solar(year, month, day)
+    function: lunar_to_solar(year, month, day, :ko)
     mday: 15
   - name: Liberation Day
     regions: [kr]

--- a/kr.yaml
+++ b/kr.yaml
@@ -11,7 +11,7 @@ months:
   1:
   - name: Korean New Year
     regions: [kr]
-    function: lunar_to_solar(year, month, day, :ko)
+    function: lunar_to_solar(year, month, day, region)
     mday: 1
   - name: New Year's Day
     regions: [kr]
@@ -23,7 +23,7 @@ months:
   4:
   - name: Buddah's Birthday
     regions: [kr]
-    function: lunar_to_solar(year, month, day, :ko)
+    function: lunar_to_solar(year, month, day, region)
     mday: 8
   5:
   - name: Children's Day
@@ -41,7 +41,7 @@ months:
   8:
   - name: Korean Thanksgiving
     regions: [kr]
-    function: lunar_to_solar(year, month, day, :ko)
+    function: lunar_to_solar(year, month, day, region)
     mday: 15
   - name: Liberation Day
     regions: [kr]

--- a/vi.yaml
+++ b/vi.yaml
@@ -11,7 +11,7 @@ months:
   3:
   - name: "Giỗ tổ Hùng Vương"
     regions: [vi]
-    function: lunar_to_solar(year, month, day, :vi)
+    function: lunar_to_solar(year, month, day, region)
     mday: 10
   4:
   - name: "Ngày Giải phóng miền Nam, thống nhất đất nước"

--- a/vi.yaml
+++ b/vi.yaml
@@ -11,7 +11,7 @@ months:
   3:
   - name: "Giỗ tổ Hùng Vương"
     regions: [vi]
-    function: lunar_to_solar(year, month, day)
+    function: lunar_to_solar(year, month, day, :vi)
     mday: 10
   4:
   - name: "Ngày Giải phóng miền Nam, thống nhất đất nước"


### PR DESCRIPTION
Following our discussion on #28, I've updated the `lunar_date` calculations and added a Vietnam specific hash.  This PR uses that new hash. 