### PR TITLE
Korean Thanksgiving is on September 15, not September 12 in 2016.  

### DIFF
--- a/kr.yaml
+++ b/kr.yaml
@@ -61,7 +61,7 @@ months:
 tests: |
   {Date.civil(2016,2,8) => "Korean New Year",
    Date.civil(2016,5,14) => "Buddah\'s Birthday",
-   Date.civil(2016,9,12) => "Korean Thanksgiving",
+   Date.civil(2016,9,15) => "Korean Thanksgiving",
    Date.civil(2016,1,1) => "New Year\'s Day",
    Date.civil(2016,3,1) => "Independence Movement Day",
    Date.civil(2016,5,5) => "Children\'s Day",


### PR DESCRIPTION
This fixes [Holidays #273](https://github.com/holidays/holidays/pull/273).  The test was just wrong!  View the correct information [on this Wikipedia article -- Midautumn Festival in 2016](https://en.wikipedia.org/wiki/List_of_public_holidays_in_South_Korea).