### PR TITLE
Correcting Canadian holidays as according to provincial rules

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -103,7 +103,7 @@ months:
     regions: [ca_nu]
     mday: 9
   8:
-  - name: BC Day
+  - name: B.C. Day
     week: 1
     regions: [ca_bc]
     wday: 1

--- a/ca.yaml
+++ b/ca.yaml
@@ -13,6 +13,7 @@ months:
   - name: Easter Sunday
     regions: [ca]
     function: easter(year)
+    type: informal
   - name: Easter Monday
     regions: [ca]
     function: easter(year)
@@ -75,7 +76,7 @@ months:
     mday: 23
   5:
   - name: Victoria Day
-    regions: [ca]
+    regions: [ca_ab, ca_bc, ca_mb, ca_nt, ca_nu, ca_on, ca_sk, ca_yt]
     function: ca_victoria_day(year)
   - name: National Patriotes Day
     regions: [ca_qc]
@@ -120,8 +121,13 @@ months:
     wday: 1
   - name: Civic Holiday
     week: 1
-    regions: [ca_on, ca_nt, ca_nu, ca_pe] # Appears to be a holiday in Ontario by convention
+    regions: [ca_nt, ca_nu, ca_pe]
     wday: 1
+  - name: Civic Holiday
+    week: 1
+    regions: [ca_on]
+    wday: 1
+    type: informal
   - name: New Brunswick Day
     week: 1
     regions: [ca_nb]
@@ -138,11 +144,11 @@ months:
   10:
   - name: Thanksgiving
     week: 2
-    regions: [ca]
+    regions: [ca_ab, ca_bc, ca_mb, ca_nt, ca_nu, ca_on, ca_sk, ca_yt]
     wday: 1
   11:
   - name: Remembrance Day
-    regions: [ ca_ab, ca_sk, ca_bc, ca_pe, ca_nl, ca_nt, ca_nu, ca_nb, ca_yt]
+    regions: [ca_ab, ca_sk, ca_bc, ca_pe, ca_nl, ca_nt, ca_nu, ca_nb, ca_yt]
     mday: 11
     observed: to_monday_if_weekend(date)
   12:
@@ -151,9 +157,14 @@ months:
     mday: 25
     observed: to_monday_if_weekend(date)
   - name: Boxing Day
-    regions: [ca]
+    regions: [ca_on]
     mday: 26
     observed: to_weekday_if_boxing_weekend(date)
+  - name: Boxing Day
+    regions: [ca_ab, ca_bc, ca_mb, ca_nb, ca_nl, ca_nt, ca_ns, ca_nu, ca_pe, ca_sk, ca_yt]
+    mday: 26
+    observed: to_weekday_if_boxing_weekend(date)
+    type: informal
 methods:
   ca_victoria_day:
     # Monday on or before May 24


### PR DESCRIPTION
### Summary
As talked about in this [issue](https://github.com/holidays/holidays/issues/240), I would like to propose that we correct some provincial rules regarding holidays in Canada. There are currently some holidays that shouldn't be nationwide, should be informal, etc. The affected holidays are:
- Easter Sunday
- Victoria Day
- Civic Holiday
- Thanksgiving
- Boxing Day

### External References to Provincial Public Holidays
- [ca_ab](https://work.alberta.ca/employment-standards/general-holidays.html)
- [ca_bc](http://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/factsheets/statutory-holidays-in-bc-2015-2018)
- [ca_mb](https://www.gov.mb.ca/labour/standards/doc,gen-holidays-after-april-30-07,factsheet.html)
- [ca_nb](http://www2.gnb.ca/content/dam/gnb/Departments/petl-epft/PDF/es/FactSheets/PublicHolidaysVacation.pdf)
- [ca_nl](http://www.cfib-fcei.ca/english/article/6421-paying-employees-for-public-holidays-nl.html)
- [ca_nt](http://www.statutoryholidays.com/nwt.php)
- [ca_ns](https://novascotia.ca/lae/employmentrights/holidaychart.asp)
- [ca_on](https://www.labour.gov.on.ca/english/es/pubs/guide/publicholidays.php)
- [ca_pe](https://www.princeedwardisland.ca/en/information/justice-and-public-safety/paid-holidays)
- [ca_sk](https://www.saskatchewan.ca/business/employment-standards/vacations-holidays-leaves-and-absences/public-statutory-holidays/list-of-saskatchewan-public-holidays)
- [ca_yt](http://www.community.gov.yk.ca/stat_holidays.html)
