### PR TITLE
Add Maltese holiday definitions

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -34,6 +34,8 @@ defs:
   LI: ['li.yaml']
   LT: ['lt.yaml']
   MA: ['ma.yaml']
+  MT_MT: ['mt_mt.yaml']
+  MT_EN: ['mt_en.yaml']
   MX: ['mx.yaml', 'north_america_informal.yaml']
   NERC: ['nerc.yaml']
   NL: ['nl.yaml']

--- a/mt_en.yaml
+++ b/mt_en.yaml
@@ -1,0 +1,80 @@
+# Maltese holiday definitions for the Ruby Holiday gem.  In English.
+#
+# Updated: 2017-06-08
+# Sources:
+# - https://en.wikipedia.org/wiki/Public_holidays_in_Malta
+---
+months:
+  0:
+  - name: Good Friday # Il-Ġimgħa l-Kbira
+    regions: [mt_en]
+    function: easter(year)
+    function_modifier: -2
+  1:
+  - name: New Year's Day # L-Ewwel tas-Sena
+    regions: [mt_en]
+    mday: 1
+  2:
+  - name: Feast of Saint Paul's Shipwreck in Malta # Nawfraġju ta' San Pawl
+    regions: [mt_en]
+    mday: 10
+  3:
+  - name: Feast of Saint Joseph # San Ġużepp
+    regions: [mt_en]
+    mday: 19
+  - name: Freedom Day # Jum il-Ħelsien
+    regions: [mt_en]
+    mday: 31
+  5:
+  - name: Worker's Day # Jum il-Ħaddiem
+    regions: [mt_en]
+    mday: 1
+  6:
+  - name: Sette Giugno
+    regions: [mt_en]
+    mday: 7
+  - name: Feast of Saint Peter & Saint Paul # L-Imnarja
+    regions: [mt_en]
+    mday: 29
+  8:
+  - name: Feast of the Assumption of Our Lady # Santa Marija
+    regions: [mt_en]
+    mday: 15
+  9:
+  - name: Victory Day # Jum il-Vitorja
+    regions: [mt_en]
+    mday: 8
+  - name: Independence Day # Jum l-Indipendenza
+    regions: [mt_en]
+    mday: 21
+  12:
+  - name: Feast of the Immaculate Conception # Il-Kunċizzjoni
+    regions: [mt_en]
+    mday: 8
+  - name: Republic Day # Jum ir-Repubblika
+    regions: [mt_en]
+    mday: 13
+  - name: Christmas Day # Il-Milied
+    regions: [mt_en]
+    mday: 25
+tests: |
+    { Date.civil(2017, 1, 1) => "New Year's Day",
+      Date.civil(2017, 2, 10) => "Feast of Saint Paul's Shipwreck in Malta",
+      Date.civil(2017, 3, 19) => 'Feast of Saint Joseph',
+      Date.civil(2017, 3, 31) => 'Freedom Day',
+      Date.civil(2017, 5, 1) => "Worker's Day",
+      Date.civil(2017, 6, 7) => 'Sette Giugno',
+      Date.civil(2017, 6, 29) => 'Feast of Saint Peter & Saint Paul',
+      Date.civil(2017, 8, 15) => 'Feast of the Assumption of Our Lady',
+      Date.civil(2017, 9, 8) => 'Victory Day',
+      Date.civil(2017, 9, 21) => 'Independence Day',
+      Date.civil(2017, 12, 8) => 'Feast of the Immaculate Conception',
+      Date.civil(2017, 12, 13) => 'Republic Day',
+      Date.civil(2017, 12, 25) => 'Christmas Day',
+    }.each do |date, name|
+      assert_equal name, (Holidays.on(date, :mt_en)[0] || {})[:name]
+    end
+
+    [Date.civil(2017, 4, 14), Date.civil(2018, 3, 30), Date.civil(2019, 4, 19)].each do |date|
+      assert_equal 'Good Friday', Holidays.on(date, :mt_en)[0][:name]
+    end

--- a/mt_mt.yaml
+++ b/mt_mt.yaml
@@ -1,0 +1,80 @@
+# Maltese holiday definitions for the Ruby Holiday gem. In Maltese.
+#
+# Updated: 2017-06-08
+# Sources:
+# - https://en.wikipedia.org/wiki/Public_holidays_in_Malta
+---
+months:
+  0:
+  - name: Il-Ġimgħa l-Kbira # Good Friday
+    regions: [mt_mt]
+    function: easter(year)
+    function_modifier: -2
+  1:
+  - name: L-Ewwel tas-Sena # New Year's Day
+    regions: [mt_mt]
+    mday: 1
+  2:
+  - name: Nawfraġju ta' San Pawl # Feast of Saint Paul's Shipwreck in Malta
+    regions: [mt_mt]
+    mday: 10
+  3:
+  - name: San Ġużepp # Feast of Saint Joseph
+    regions: [mt_mt]
+    mday: 19
+  - name: Jum il-Ħelsien # Freedom Day
+    regions: [mt_mt]
+    mday: 31
+  5:
+  - name: Jum il-Ħaddiem #  Worker's Day
+    regions: [mt_mt]
+    mday: 1
+  6:
+  - name: Sette Giugno
+    regions: [mt_mt]
+    mday: 7
+  - name: L-Imnarja # Feast of Saint Peter & Saint Paul
+    regions: [mt_mt]
+    mday: 29
+  8:
+  - name: Santa Marija # Feast of the Assumption of Our Lady
+    regions: [mt_mt]
+    mday: 15
+  9:
+  - name: Jum il-Vitorja # Victory Day
+    regions: [mt_mt]
+    mday: 8
+  - name: Jum l-Indipendenza #  Independence Day
+    regions: [mt_mt]
+    mday: 21
+  12:
+  - name: Il-Kunċizzjoni # Feast of the Immaculate Conception
+    regions: [mt_mt]
+    mday: 8
+  - name: Jum ir-Repubblika # Republic Day
+    regions: [mt_mt]
+    mday: 13
+  - name: Il-Milied # Christmas Day
+    regions: [mt_mt]
+    mday: 25
+tests: |
+    { Date.civil(2017, 1, 1) => 'L-Ewwel tas-Sena',
+      Date.civil(2017, 2, 10) => "Nawfraġju ta' San Pawl",
+      Date.civil(2017, 3, 19) => 'San Ġużepp',
+      Date.civil(2017, 3, 31) => 'Jum il-Ħelsien',
+      Date.civil(2017, 5, 1) => 'Jum il-Ħaddiem',
+      Date.civil(2017, 6, 7) => 'Sette Giugno',
+      Date.civil(2017, 6, 29) => 'L-Imnarja',
+      Date.civil(2017, 8, 15) => 'Santa Marija',
+      Date.civil(2017, 9, 8) => 'Jum il-Vitorja',
+      Date.civil(2017, 9, 21) => 'Jum l-Indipendenza',
+      Date.civil(2017, 12, 8) => 'Il-Kunċizzjoni',
+      Date.civil(2017, 12, 13) => 'Jum ir-Repubblika',
+      Date.civil(2017, 12, 25) => 'Il-Milied',
+    }.each do |date, name|
+      assert_equal name, (Holidays.on(date, :mt_mt)[0] || {})[:name]
+    end
+
+    [Date.civil(2017, 4, 14), Date.civil(2018, 3, 30), Date.civil(2019, 4, 19)].each do |date|
+      assert_equal 'Il-Ġimgħa l-Kbira', Holidays.on(date, :mt_mt)[0][:name]
+    end


### PR DESCRIPTION
Malta has two official languages: Maltese and English
- mt_mt.yaml offers holiday definitions in Maltese
- mt_en.yaml offers holiday definitions in English
- Tests are included