### PR TITLE
Remove ruby 2.1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ notifications:
     holidaysgem@gmail.com
 
 rvm:
-  - 2.1.0
   - 2.2.0
   - 2.3.0
   - 2.4.0


### PR DESCRIPTION
Ruby 2.1 is no more maintained.
See [detail](https://github.com/rvm/rvm/commit/03f468d4b6c31420e98e8d84db1a19b61a199f6b) .