### PR TITLE
Heritage Day in Alberta is informal

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -114,6 +114,7 @@ months:
   - name: Heritage Day
     week: 1
     regions: [ca_ab]
+    type: informal
     wday: 1
   - name: Natal Day
     week: 1


### PR DESCRIPTION
According to [this Alberta resource](http://work.alberta.ca/employment-standards/alberta-general-holidays.html) Heritage Day is treated as an informal holiday, much like Civic holiday in Ontario.