### PR TITLE
Update Chilean (CL) Holiday Definitions 

### DIFF
--- a/cl.yaml
+++ b/cl.yaml
@@ -58,9 +58,13 @@ months:
   - name: Encuentro de Dos Mundos
     regions: [cl]
     mday: 12
-  - name: Día de las Iglesias Evangélicas y Protestantes
+    year_ranges:
+      - before: 1999
+  - name: Encuentro de Dos Mundos
     regions: [cl]
-    mday: 31
+    year_ranges:
+      - after: 2000
+    function: columbus_day_cl(year) 
   11:
   - name: Día de Todos los Santos
     regions: [cl]
@@ -78,6 +82,18 @@ methods:
     # Nearest monday
     source: |
       date = Date.civil(year, 6, 29)
+      if [2,3,4].include?(date.wday)
+        date -= (date.wday - 1)
+      elsif date.wday == 5
+        date += 3
+      end
+
+      date
+  columbus_day_cl:
+    arguments: year
+    # Nearest monday
+    source: |
+      date = Date.civil(year, 10, 12)
       if [2,3,4].include?(date.wday)
         date -= (date.wday - 1)
       elsif date.wday == 5
@@ -226,7 +242,13 @@ tests:
     expect:
       name: "Día de las Glorias del Ejército"
   - given:
-      date: '2014-10-12'
+      date: '1999-10-12'
+      regions: ["cl"]
+      options: ["informal"]
+    expect:
+      name: "Encuentro de Dos Mundos"
+  - given:
+      date: '2017-10-9'
       regions: ["cl"]
       options: ["informal"]
     expect:

--- a/cl.yaml
+++ b/cl.yaml
@@ -22,6 +22,11 @@ months:
     function: st_peter_st_paul_cl(year)
     year_ranges:
       - after: 2000
+  - name: Día de las Iglesias Evangélicas y Protestantes
+    regions: [cl]
+    function: other_churches_day_cl(year)
+    year_ranges:
+      - after: 2008
   1:
   - name: Año Nuevo
     regions: [cl]
@@ -101,7 +106,18 @@ methods:
       end
 
       date
+  other_churches_day_cl:
+    arguments: year
+    # If on tuesday, friday before, if on wednesday, next friday
+    source: |
+      date = Date.civil(year, 10, 31)
+      if date.wday == 2
+        date -= 4
+      elsif date.wday == 3
+        date += 2
+      end
 
+      date
 tests:
   - given:
       date: '2014-01-01'
@@ -254,7 +270,7 @@ tests:
     expect:
       name: "Encuentro de Dos Mundos"
   - given:
-      date: '2014-10-31'
+      date: '2017-10-27'
       regions: ["cl"]
       options: ["informal"]
     expect:

--- a/cl.yaml
+++ b/cl.yaml
@@ -1,9 +1,10 @@
 # Chilean holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2014-10-08
+# Updated: 2014-8-9
 #
 # Sources:
 # - http://www.feriados.cl
+# - http://www.feriadoschilenos.cl
 #
 ---
 months:
@@ -16,6 +17,11 @@ months:
     regions: [cl]
     function: easter(year)
     function_modifier: -1
+  - name: San Pedro y San Pablo
+    regions: [cl]
+    function: st_peter_st_paul_cl(year)
+    year_ranges:
+      - after: 2000
   1:
   - name: Año Nuevo
     regions: [cl]
@@ -31,6 +37,8 @@ months:
   - name: San Pedro y San Pablo
     regions: [cl]
     mday: 29
+    year_ranges:
+      - before: 1999
   7:
   - name: Día de la Virgen del Carmen
     regions: [cl]
@@ -64,6 +72,19 @@ months:
   - name: Navidad
     regions: [cl]
     mday: 25
+methods:
+  st_peter_st_paul_cl:
+    arguments: year
+    # Nearest monday
+    source: |
+      date = Date.civil(year, 6, 29)
+      if [2,3,4].include?(date.wday)
+        date -= (date.wday - 1)
+      elsif date.wday == 5
+        date += 3
+      end
+
+      date
 
 tests:
   - given:
@@ -157,7 +178,25 @@ tests:
     expect:
       name: "Día de las Glorias Navales"
   - given:
-      date: '2014-06-29'
+      date: '1999-06-29'
+      regions: ["cl"]
+      options: ["informal"]
+    expect:
+      name: "San Pedro y San Pablo"
+  - given:
+      date: '2000-06-26'
+      regions: ["cl"]
+      options: ["informal"]
+    expect:
+      name: "San Pedro y San Pablo"
+  - given:
+      date: '2017-06-26'
+      regions: ["cl"]
+      options: ["informal"]
+    expect:
+      name: "San Pedro y San Pablo"
+  - given:
+      date: '2018-07-2'
       regions: ["cl"]
       options: ["informal"]
     expect:


### PR DESCRIPTION
Updates the following chilean holiday definitions:

- **St. Peter and St. Paul (San Pedro y San Pablo):** Since 2000 it is the nearest monday of 6/29
- **Columbus Day (Encuentro de dos mundos):** Since 2000 it is nearest monday of 10/12
- **Other Curches Day (Día de las Iglesias Evangélicas y Protestantes):** A new holiday since 2008 that works with the following logic: it is on the 10/31 unless it is on a tuesday which changes it to the friday before and if it lands on a wednesday, then is moved to the next friday.

The rules for all of these holidays is taken from: http://www.feriadoschilenos.cl (sorry it's in spanish)