### PR TITLE
Audit provincial holidays in Canada

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -131,7 +131,7 @@ months:
     wday: 1
   - name: Civic Holiday
     week: 1
-    regions: [ca_on]
+    regions: [ca_on, ca_pe]
     wday: 1
     type: informal
   - name: New Brunswick Day

--- a/ca.yaml
+++ b/ca.yaml
@@ -70,10 +70,12 @@ months:
   - name: St. Patrick's Day
     regions: [ca_nl]
     mday: 17
+    type: informal
   3:
   - name: St. George's Day
     regions: [ca_nl]
     mday: 23
+    type: informal
   5:
   - name: Victoria Day
     regions: [ca_ab, ca_bc, ca_mb, ca_nt, ca_nu, ca_on, ca_sk, ca_yt]
@@ -85,6 +87,7 @@ months:
   - name: Discovery Day
     regions: [ca_nl]
     mday: 24
+    type: informal
   - name: Fête Nationale
     regions: [ca_qc]
     mday: 24
@@ -99,6 +102,7 @@ months:
   - name: Orangemen's Day
     regions: [ca_nl]
     mday: 12
+    type: informal
   - name: Nunavut Day
     regions: [ca_nu]
     mday: 9
@@ -120,9 +124,10 @@ months:
     week: 1
     regions: [ca_ns]
     wday: 1
+    type: informal
   - name: Civic Holiday
     week: 1
-    regions: [ca_nt, ca_nu, ca_pe]
+    regions: [ca_nt, ca_nu]
     wday: 1
   - name: Civic Holiday
     week: 1

--- a/lib/validation/test_validator.rb
+++ b/lib/validation/test_validator.rb
@@ -60,7 +60,7 @@ module Definitions
         given["date"].each do |d|
           begin
             DateTime.parse(d)
-          rescue TypeError, ArgumentError
+          rescue TypeError, ArgumentError, NoMethodError
             err!("Test must contain valid date, date value was: '#{d}")
           end
         end


### PR DESCRIPTION
I did an audit [already](https://github.com/holidays/definitions/pull/38), but was not careful the first time, so I missed some informal holidays. Here is another audit where I used the same external references to make holidays informal where necessary.

### External References to Provincial Public Holidays
- [ca_ab](https://work.alberta.ca/employment-standards/general-holidays.html)
- [ca_bc](http://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/factsheets/statutory-holidays-in-bc-2015-2018)
- [ca_mb](https://www.gov.mb.ca/labour/standards/doc,gen-holidays-after-april-30-07,factsheet.html)
- [ca_nb](http://www2.gnb.ca/content/dam/gnb/Departments/petl-epft/PDF/es/FactSheets/PublicHolidaysVacation.pdf)
- [ca_nl](http://www.cfib-fcei.ca/english/article/6421-paying-employees-for-public-holidays-nl.html)
- [ca_nt](http://www.statutoryholidays.com/nwt.php)
- [ca_ns](https://novascotia.ca/lae/employmentrights/holidaychart.asp)
- [ca_on](https://www.labour.gov.on.ca/english/es/pubs/guide/publicholidays.php)
- [ca_pe](https://www.princeedwardisland.ca/en/information/justice-and-public-safety/paid-holidays)
- [ca_sk](https://www.saskatchewan.ca/business/employment-standards/vacations-holidays-leaves-and-absences/public-statutory-holidays/list-of-saskatchewan-public-holidays)
- [ca_yt](http://www.community.gov.yk.ca/stat_holidays.html)
