### PR TITLE
Correct Reformation Day in German holiday definitions

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -14,6 +14,9 @@
 # - Mariä Himmelfahrt is celebrated in the community of Augsburg (de_by_augsburg)
 # - Enhance tests
 #
+# Changes 2017-09-25:
+# - Correct definition for Reformation Day
+#
 # Sources:
 # - http://en.wikipedia.org/wiki/Holidays_in_Germany
 # - http://www.timeanddate.com/calendar/index.html?country=8

--- a/de.yaml
+++ b/de.yaml
@@ -90,7 +90,7 @@ months:
     regions: [de]
     mday: 3
   - name: Reformationstag
-    regions: [de_sh, de_ni, de_hh, de_hb, de_be, de_bb, de_mv, de_sn, de_st, de_th]
+    regions: [de_bb, de_mv, de_sn, de_st, de_th]
     mday: 31
   - name: Reformationstag
     regions: [de_bw]
@@ -257,6 +257,16 @@ tests:
       regions: ["de"]
     expect:
       holiday: false
+  - given:
+      date: '2019-10-31'
+      regions: ["de_sh", "de_ni", "de_hh", "de_hb", "de_be"]
+    expect:
+      holiday: false
+  - given:
+      date: '2019-10-31'
+      regions: ["de_bb", "de_mv", "de_sn", "de_st", "de_th"]
+    expect:
+      name: "Reformationstag"
   - given:
       date: '2009-11-01'
       regions: ["de_bw", "de_by", "de_nw", "de_rp", "de_sl", "de_"]


### PR DESCRIPTION
Reformation Day is only a state holiday in `de_bb`, `de_mv`, `de_sn`, `de_st` and `de_th`. This PR is going to correct that.

Included Changes:

* Correct definition for Reformation Day 
* Enhance tests

Related to issue https://github.com/holidays/definitions/issues/73