### PR TITLE
Added holidays for Jersey and Guernsey

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -22,7 +22,7 @@ months:
     regions: [gb]
     function: easter(year)
   - name: Easter Monday
-    regions: [gb_eng, gb_wls, gb_eaw, gb_nir]
+    regions: [gb_eng, gb_wls, gb_eaw, gb_nir, je, gb_jsy, gg, gb_gsy]
     function: easter(year)
     function_modifier: 1
   1:
@@ -66,7 +66,7 @@ months:
     week: 1
     wday: 1
   - name: Bank Holiday
-    regions: [gb_eng, gb_wls, gb_eaw, gb_nir]
+    regions: [gb_eng, gb_wls, gb_eaw, gb_nir, je, gb_jsy, gg, gb_gsy]
     week: -1
     wday: 1
   11:
@@ -355,5 +355,20 @@ tests:
   - given:
       date: '2008-08-25'
       regions: ["gb_"]
+    expect:
+      name: "Bank Holiday"
+  - given:
+      date: '2018-05-09'
+      regions: ["je"]
+    expect:
+      name: "Liberation Day"
+  - given:
+      date: '2018-04-02'
+      regions: ["je"]
+    expect:
+      name: "Easter Monday"
+  - given:
+      date: '2018-08-27'
+      regions: ["je"]
     expect:
       name: "Bank Holiday"


### PR DESCRIPTION
Added relevant holidays for `je, gb_jsy, gg, gb_gsy`, using data from:

https://www.gov.je/Leisure/Events/WhatsOn/Pages/BankHolidayDates.aspx
https://www.gov.gg/article/120214/Public-and-school-holiday-dates

I have added tests - but it is not clear how to run these tests in the `definitions` repository.