### PR TITLE
German Reformation Day in four more states starting in 2018

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -17,6 +17,9 @@
 # Changes 2017-09-25:
 # - Correct definition for Reformation Day
 #
+# Changes 2018-09-10:
+#  - Reformation Day has been added as a new holiday in Bremen, Hamburg, Lower Saxony and Schleswig-Holstein, starting in 2018.
+#
 # Sources:
 # - http://en.wikipedia.org/wiki/Holidays_in_Germany
 # - http://www.timeanddate.com/calendar/index.html?country=8
@@ -104,6 +107,11 @@ months:
     mday: 31
     year_ranges:
     - limited: [2017]
+  - name: Reformationstag
+    regions: [de_hb, de_hh, de_ni, de_sh]
+    mday: 31
+    year_ranges:
+    - after: [2018]
   11:
   - name: Allerheiligen
     regions: [de_bw, de_by, de_nw, de_rp, de_sl]
@@ -261,8 +269,8 @@ tests:
     expect:
       holiday: false
   - given:
-      date: '2019-10-31'
-      regions: ["de_bb", "de_mv", "de_sn", "de_st", "de_th"]
+      date: '2018-10-31'
+      regions: ["de_bb", "de_hb", "de_hh", "de_mv", "de_ni", "de_sh", "de_sn", "de_st", "de_th"]
     expect:
       name: "Reformationstag"
   - given:


### PR DESCRIPTION
The German "Reformation Day" has been added permanently as a new holiday in Bremen, Hamburg, Lower Saxony and Schleswig-Holstein, starting in 2018. See note "(9)" at https://en.wikipedia.org/wiki/Public_holidays_in_Germany

It'd be great if this could be added to the Holidays gem and released there before this holiday's first occurrence on 2018-10-31.