### PR TITLE
Update Neujahrstag to apply to overall swiss region and bump to v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Holiday definitions
 
+## 3.1.0
+
+* Update `ch` to apply 'Neujahrstag' to overall region (thanks to https://github.com/phylor)
+* Cosmetic spacing update for `us` definition, no behavior change
+
 ## 3.0.0
 
 Major semver bump as the format for custom methods has been changed to complete [issue-24](https://github.com/holidays/definitions/issues/24). Downstream consumers will need to update to be able to parse them. However there are **no behavior changes** with this update.

--- a/ch.yaml
+++ b/ch.yaml
@@ -1,6 +1,6 @@
 # Swiss holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2012-03-16.
+# Updated: 2018-10-10.
 # Sources:
 #  http://www.bj.admin.ch/content/dam/data/staat_buerger/zivilprozessrecht/kant-feiertage.pdf
 #
@@ -24,12 +24,6 @@
 # * ch_ai: - 22nd of September is celebrated only in part of the state.
 #          - 26th of December is not celebrated in case the 25th is a Monday or a Friday.
 # * ch_ne: 26th of December and 2nd of January are only celebrated in case 25th of December and 1st of January are Sundays
-#
-#
-#
-# all regions [ch_zh, ch_be, ch_lu, ch_ur, ch_sz, ch_ow, ch_nw, ch_gl, ch_zg, ch_fr, ch_so, ch_bs, ch_bl,
-# ch_sh, ch_ar, ch_ai, ch_sg, ch_gr, ch_ag, ch_tg, ch_ti, ch_vd, ch_vs, ch_ne, ch_ge, ch_ju]
-#
 ---
 months:
   0:
@@ -62,7 +56,7 @@ months:
     function: ch_ge_jeune_genevois(year)
   1:
   - name: Neujahrstag
-    regions: [ch_zh, ch_be, ch_lu, ch_ur, ch_sz, ch_ow, ch_nw, ch_gl, ch_zg, ch_fr, ch_so, ch_bs, ch_bl, ch_sh, ch_ar, ch_ai, ch_sg, ch_gr, ch_ag, ch_tg, ch_vd, ch_vs, ch_ne, ch_ge, ch_ju, ch_ti]
+    regions: [ch]
     mday: 1
   - name: Berchtoldstag
     regions: [ch_zh, ch_be, ch_lu, ch_ow, ch_nw, ch_gl, ch_zg, ch_fr, ch_so, ch_sh, ch_sg, ch_ag, ch_tg, ch_vd, ch_vs, ch_ne, ch_ju]
@@ -166,6 +160,11 @@ methods:
       date
 
 tests:
+  - given:
+      date: '2018-01-01'
+      regions: ["ch"]
+    expect:
+      name: "Neujahrstag"
   - given:
       date: '2012-08-01'
       regions: ["ch"]

--- a/us.yaml
+++ b/us.yaml
@@ -65,7 +65,9 @@
 # - http://www.kleiner-kalender.de/event/rosch-ha-schana/0651c.html
 # - http://www.kaldix.com/united-states/calendar/virginia/holidays/independence-day/year-2017/
 # - https://publicholidays.us/independence-day/
+
 ---
+
 months:
   0:
   - name: Shrove Tuesday


### PR DESCRIPTION
Based on changes submitted to generated definitions in https://github.com/holidays/holidays/pull/325