### PR TITLE
Add definition for federal reserve holidays when banks are open.

### DIFF
--- a/federal_reserve_banks.yaml
+++ b/federal_reserve_banks.yaml
@@ -1,0 +1,365 @@
+# Federal reserve holidays definition for the Ruby Holiday gem.
+# Observed option applies to when banks are open.
+#
+# Updated: 2018-11-26
+#
+# Sources:
+#  - http://www.federalreserve.gov/aboutthefed/k8.htm
+---
+months:
+  1:
+  - name: New Year's Day
+    regions: [federal_reserve_banks]
+    mday: 1
+    observed: to_monday_if_sunday(date)
+  - name: Birthday of Martin Luther King, Jr
+    week: 3
+    wday: 1
+    regions: [federal_reserve_banks]
+  2:
+  - name: Washington's Birthday
+    week: 3
+    wday: 1
+    regions: [federal_reserve_banks]
+  5:
+  - name: Memorial Day
+    week: -1
+    wday: 1
+    regions: [federal_reserve_banks]
+  7:
+  - name: Independence Day
+    regions: [federal_reserve_banks]
+    mday: 4
+    observed: to_monday_if_sunday(date)
+  9:
+  - name: Labor Day
+    week: 1
+    regions: [federal_reserve_banks]
+    wday: 1
+  10:
+  - name: Columbus Day
+    week: 2
+    regions: [federal_reserve_banks]
+    wday: 1
+  11:
+  - name: Veterans Day
+    regions: [federal_reserve_banks]
+    mday: 11
+    observed: to_monday_if_sunday(date)
+  - name: Thanksgiving Day
+    week: 4
+    wday: 4
+    regions: [federal_reserve_banks]
+  12:
+  - name: Christmas Day
+    regions: [federal_reserve_banks]
+    mday: 25
+    observed: to_monday_if_sunday(date)
+
+tests:
+  - given:
+      date: '2012-01-02'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2012-01-16'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Birthday of Martin Luther King, Jr"
+  - given:
+      date: '2012-02-20'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Washington's Birthday"
+  - given:
+      date: '2012-05-28'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Memorial Day"
+  - given:
+      date: '2012-07-04'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: '2020-07-03'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: '2012-09-03'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Labor Day"
+  - given:
+      date: '2012-10-08'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Columbus Day"
+  - given:
+      date: '2012-11-12'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Veterans Day"
+  - given:
+      date: '2012-11-22'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Thanksgiving Day"
+  - given:
+      date: '2012-12-25'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2013-01-01'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2013-01-21'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Birthday of Martin Luther King, Jr"
+  - given:
+      date: '2013-02-18'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Washington's Birthday"
+  - given:
+      date: '2013-05-27'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Memorial Day"
+  - given:
+      date: '2013-07-04'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: '2013-09-02'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Labor Day"
+  - given:
+      date: '2013-10-14'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Columbus Day"
+  - given:
+      date: '2013-11-11'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Veterans Day"
+  - given:
+      date: '2013-11-28'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Thanksgiving Day"
+  - given:
+      date: '2013-12-25'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2014-01-01'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2014-01-20'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Birthday of Martin Luther King, Jr"
+  - given:
+      date: '2014-02-17'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Washington's Birthday"
+  - given:
+      date: '2014-05-26'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Memorial Day"
+  - given:
+      date: '2014-07-04'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: '2014-09-01'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Labor Day"
+  - given:
+      date: '2014-10-13'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Columbus Day"
+  - given:
+      date: '2014-11-11'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Veterans Day"
+  - given:
+      date: '2014-11-27'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Thanksgiving Day"
+  - given:
+      date: '2014-12-25'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2015-01-01'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2015-01-19'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Birthday of Martin Luther King, Jr"
+  - given:
+      date: '2015-02-16'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Washington's Birthday"
+  - given:
+      date: '2015-05-25'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Memorial Day"
+  - given:
+      date: '2015-07-03'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: '2015-09-07'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Labor Day"
+  - given:
+      date: '2015-10-12'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Columbus Day"
+  - given:
+      date: '2015-11-11'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Veterans Day"
+  - given:
+      date: '2015-11-26'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Thanksgiving Day"
+  - given:
+      date: '2015-12-25'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2016-01-01'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2016-01-18'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Birthday of Martin Luther King, Jr"
+  - given:
+      date: '2016-02-15'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Washington's Birthday"
+  - given:
+      date: '2016-05-30'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Memorial Day"
+  - given:
+      date: '2016-07-04'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: '2016-09-05'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Labor Day"
+  - given:
+      date: '2016-10-10'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Columbus Day"
+  - given:
+      date: '2016-11-11'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Veterans Day"
+  - given:
+      date: '2016-11-24'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Thanksgiving Day"
+  - given:
+      date: '2016-12-26'
+      regions: ["federal_reserve_banks"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"

--- a/index.yaml
+++ b/index.yaml
@@ -21,6 +21,7 @@ defs:
   EL: ['el.yaml']
   ES: ['es.yaml']
   Federal_Reserve: ['federal_reserve.yaml']
+  Federal_Reserve_Banks: ['federal_reserve_banks.yaml']
   FedEx: ['fedex.yaml']
   FI: ['fi.yaml']
   FR: ['fr.yaml']


### PR DESCRIPTION
We've been relying on these definitions for when banks open.

holidays/definitions#87 broke this assumption since it changes it to when holidays are observed by the Board of Governors instead of when banks are open.

This seemed to simplest way to add a definition for purely banking holidays.