### PR TITLE
Add civic holiday (Terry Fox Day) for ca_mb

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -157,6 +157,10 @@ months:
     week: 1
     regions: [ca_nb]
     wday: 1
+  - name: Terry Fox Day
+    week: 1
+    regions: [ca_mb]
+    wday: 1
   - name: Discovery Day
     week: 3
     regions: [ca_yt]


### PR DESCRIPTION
The civic holiday for Manitoba, Canada was missing in August. 
 Added Terry Fox Day as mentioned at https://www.timeanddate.com/holidays/canada/civic-provincial-day