### PR TITLE
Add Berlin's new International Women's Day

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -80,6 +80,12 @@ months:
   - name: Heilige Drei Könige
     regions: [de_bw, de_by, de_st]
     mday: 6
+  3:
+    - name: Internationaler Frauentag
+      regions: [de_be]
+      mday: 8
+      year_ranges:
+        - after: 2019
   5:
   - name: Tag der Arbeit
     regions: [de]
@@ -336,3 +342,13 @@ tests:
       options: ["informal"]
     expect:
       name: "Aschermittwoch"
+  - given:
+      date: '2018-03-08'
+      regions: ["de_be"]
+    expect:
+      holiday: false
+  - given:
+      date: '2019-03-08'
+      regions: ["de_be"]
+    expect:
+      name: "Internationaler Frauentag"


### PR DESCRIPTION
Berlin has just officially announced that the International Women's Day will be a public holiday from this year on, see https://www.berliner-zeitung.de/berlin/beschlossene-sache-der-8--maerz-ist-nun-offiziell-ein-berliner-feiertag-31927822 (in German).

As this is my first contribution, please check whether everything is correct, including the tests which I couldn't run.