### PR TITLE
[issue-117] Update year_ranges for usage clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Holiday definitions
 
+## 5.0.0
+
+Major semver bump due to changes related to the `year_ranges` option. The following keys have been renamed:
+
+* `before` is now `until`
+* `after` is now `from`
+
+The behavior of these two options has not changed. To read more about the reasons behind this change please see the [associated ADR](doc/architecture/adr-002.md).
+
 ## 4.1.0
 
 * Add new Emperor's Coronation Day holiday to `jp` (thanks to https://github.com/ttwo32)

--- a/au.yaml
+++ b/au.yaml
@@ -23,7 +23,7 @@ months:
     regions: [au_qld, au_act]
     function: easter(year)
     year_ranges:
-      - from: 2017
+      from: 2017
   - name: Easter Monday
     regions: [au]
     function: easter(year)

--- a/au.yaml
+++ b/au.yaml
@@ -1,5 +1,5 @@
 # Australian holiday definitions for the Ruby Holiday gem.
-# Updated: 2018-08-30
+# Updated: 2019-02-10
 # Sources:
 # - http://en.wikipedia.org/wiki/Australian_public_holidays
 # - http://www.docep.wa.gov.au/lr/LabourRelations/Content/Wages%20and%20Conditions/Public%20Holidays/Public_Holidays.html
@@ -23,7 +23,7 @@ months:
     regions: [au_qld, au_act]
     function: easter(year)
     year_ranges:
-      - after: 2017
+      - from: 2017
   - name: Easter Monday
     regions: [au]
     function: easter(year)

--- a/ca.yaml
+++ b/ca.yaml
@@ -35,37 +35,39 @@ months:
     wday: 1
     week: 3
     year_ranges:
-    - from: 1990
+      from: 1990
   - name: Family Day
     regions: [ca_sk]
     wday: 1
     week: 3
     year_ranges:
-    - from: 2007
+      from: 2007
   - name: Family Day
     regions: [ca_on]
     wday: 1
     week: 3
     year_ranges:
-    - from: 2008
+      from: 2008
   - name: Family Day
     regions: [ca_bc]
     wday: 1
     week: 2
     year_ranges:
-    - between: 2013..2018
+      between:
+        start: 2013
+        end: 2018
   - name: Family Day
     regions: [ca_bc]
     wday: 1
     week: 3
     year_ranges:
-    - from: 2019
+      from: 2019
   - name: Family Day
     regions: [ca_nb]
     wday: 1
     week: 3
     year_ranges:
-    - from: 2018
+      from: 2018
   - name: Louis Riel Day
     regions: [ca_mb]
     wday: 1
@@ -75,7 +77,7 @@ months:
     wday: 1
     week: 3
     year_ranges:
-    - from: 2015
+      from: 2015
   - name: Islander Day
     regions: [ca_pe]
     wday: 1
@@ -111,7 +113,7 @@ months:
     regions: [ca_yt]
     mday: 21
     year_ranges:
-    - from: 2017
+      from: 2017
   7:
   - name: Canada Day
     regions: [ca]

--- a/ca.yaml
+++ b/ca.yaml
@@ -1,5 +1,5 @@
 # Canadian holiday definitions for the Ruby Holiday gem.
-# Updated 2018-03-02.
+# Updated 2019-02-10.
 #
 # Notes:
 #  - 'Family Day' in various provinces are only celebrated after certain years: http://www.timeanddate.com/holidays/canada/family-day
@@ -35,19 +35,19 @@ months:
     wday: 1
     week: 3
     year_ranges:
-    - after: 1990
+    - from: 1990
   - name: Family Day
     regions: [ca_sk]
     wday: 1
     week: 3
     year_ranges:
-    - after: 2007
+    - from: 2007
   - name: Family Day
     regions: [ca_on]
     wday: 1
     week: 3
     year_ranges:
-    - after: 2008
+    - from: 2008
   - name: Family Day
     regions: [ca_bc]
     wday: 1
@@ -59,13 +59,13 @@ months:
     wday: 1
     week: 3
     year_ranges:
-    - after: 2019
+    - from: 2019
   - name: Family Day
     regions: [ca_nb]
     wday: 1
     week: 3
     year_ranges:
-    - after: 2018
+    - from: 2018
   - name: Louis Riel Day
     regions: [ca_mb]
     wday: 1
@@ -75,7 +75,7 @@ months:
     wday: 1
     week: 3
     year_ranges:
-    - after: 2015
+    - from: 2015
   - name: Islander Day
     regions: [ca_pe]
     wday: 1
@@ -111,7 +111,7 @@ months:
     regions: [ca_yt]
     mday: 21
     year_ranges:
-    - after: 2017
+    - from: 2017
   7:
   - name: Canada Day
     regions: [ca]

--- a/cl.yaml
+++ b/cl.yaml
@@ -21,12 +21,12 @@ months:
     regions: [cl]
     function: st_peter_st_paul_cl(year)
     year_ranges:
-      - from: 2000
+      from: 2000
   - name: Día de las Iglesias Evangélicas y Protestantes
     regions: [cl]
     function: other_churches_day_cl(year)
     year_ranges:
-      - from: 2008
+      from: 2008
   1:
   - name: Año Nuevo
     regions: [cl]
@@ -43,7 +43,7 @@ months:
     regions: [cl]
     mday: 29
     year_ranges:
-      - until: 1999
+      until: 1999
   7:
   - name: Día de la Virgen del Carmen
     regions: [cl]
@@ -64,11 +64,11 @@ months:
     regions: [cl]
     mday: 12
     year_ranges:
-      - until: 1999
+      until: 1999
   - name: Encuentro de Dos Mundos
     regions: [cl]
     year_ranges:
-      - from: 2000
+      from: 2000
     function: columbus_day_cl(year)
   11:
   - name: Día de Todos los Santos

--- a/cl.yaml
+++ b/cl.yaml
@@ -1,6 +1,6 @@
 # Chilean holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2014-8-9
+# Updated: 2019-02-10
 #
 # Sources:
 # - http://www.feriados.cl
@@ -21,12 +21,12 @@ months:
     regions: [cl]
     function: st_peter_st_paul_cl(year)
     year_ranges:
-      - after: 2000
+      - from: 2000
   - name: Día de las Iglesias Evangélicas y Protestantes
     regions: [cl]
     function: other_churches_day_cl(year)
     year_ranges:
-      - after: 2008
+      - from: 2008
   1:
   - name: Año Nuevo
     regions: [cl]
@@ -43,7 +43,7 @@ months:
     regions: [cl]
     mday: 29
     year_ranges:
-      - before: 1999
+      - until: 1999
   7:
   - name: Día de la Virgen del Carmen
     regions: [cl]
@@ -64,11 +64,11 @@ months:
     regions: [cl]
     mday: 12
     year_ranges:
-      - before: 1999
+      - until: 1999
   - name: Encuentro de Dos Mundos
     regions: [cl]
     year_ranges:
-      - after: 2000
+      - from: 2000
     function: columbus_day_cl(year)
   11:
   - name: Día de Todos los Santos

--- a/de.yaml
+++ b/de.yaml
@@ -1,6 +1,6 @@
 # German holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2016-11-27
+# Updated: 2019-02-10
 #
 # Changes 2016-11-27:
 # - Change de_sn_aux, de_th_aux to de_sn_sorbian (because it only is celebrated in Sorbian regions in Sachsen) and de_th_eichsfeld, to reflect region of Eichsfeld
@@ -19,6 +19,9 @@
 #
 # Changes 2018-09-10:
 #  - Reformation Day has been added as a new holiday in Bremen, Hamburg, Lower Saxony and Schleswig-Holstein, starting in 2018.
+#
+# Change 2019-02-10:
+#  - Changing usage of 'year_ranges.after' to 'year_ranges.from', see https://github.com/holidays/definitions/issues/117
 #
 # Sources:
 # - http://en.wikipedia.org/wiki/Holidays_in_Germany
@@ -85,7 +88,7 @@ months:
       regions: [de_be]
       mday: 8
       year_ranges:
-        - after: 2019
+        - from: 2019
   5:
   - name: Tag der Arbeit
     regions: [de]
@@ -117,7 +120,7 @@ months:
     regions: [de_hb, de_hh, de_ni, de_sh]
     mday: 31
     year_ranges:
-    - after: 2018
+    - from: 2018
   11:
   - name: Allerheiligen
     regions: [de_bw, de_by, de_nw, de_rp, de_sl]

--- a/de.yaml
+++ b/de.yaml
@@ -88,7 +88,7 @@ months:
       regions: [de_be]
       mday: 8
       year_ranges:
-        - from: 2019
+        from: 2019
   5:
   - name: Tag der Arbeit
     regions: [de]
@@ -115,12 +115,12 @@ months:
     regions: [de]
     mday: 31
     year_ranges:
-    - limited: [2017]
+      limited: [2017]
   - name: Reformationstag
     regions: [de_hb, de_hh, de_ni, de_sh]
     mday: 31
     year_ranges:
-    - from: 2018
+      from: 2018
   11:
   - name: Allerheiligen
     regions: [de_bw, de_by, de_nw, de_rp, de_sl]

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -120,7 +120,7 @@ Certain holidays in various countries are only in effect during specific year ra
 * An existing holiday that has been cancelled so that the final year in effect is 2019
 * A historical holiday that was only in effect from 2002 through 2006
 
-To address these kinds of scenarios we have the ability to specify 'year ranges' for individual holiday definitions. There are a total of four selectors that can be specified. All must be specified in terms of 'years'.
+To address these kinds of scenarios we have the ability to specify 'year ranges' for individual holiday definitions. There are a total of four selectors that can be specified. All must be specified in terms of 'years'. Only one selector can be used at a time.
 
 #### `until`
 
@@ -136,7 +136,7 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - until: 2002
+    until: 2002
 ```
 
 This will return successfully since the date is before 2002:
@@ -171,7 +171,7 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - from: 2002
+    from: 2002
 ```
 
 This will return successfully since the date is after 2002:
@@ -197,11 +197,9 @@ Holidays.on(Date.civil(2000, 7, 1), :jp)
 The 'limited' selector will only find a match if the supplied date takes place during
 one of the specified years. Multiple years can be specified.
 
-An array of integers representing years *must* be supplied. Individual values will result in an error.
+An array of integers representing years *must* be supplied. Providing anything other than an array of integers will result in an error.
 
-Please note that this is *not* a range! This is an array of specific years during which the holiday is active.
-
-If you need a year range please see the `between` selector below.
+Please note that this is *not* a range! This is an array of specific years during which the holiday is active. If you need a year range please see the `between` selector below.
 
 Example:
 
@@ -211,7 +209,7 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - limited: [2002,2004]
+    limited: [2002,2004]
 ```
 
 Both of these examples will return successfully since the dates takes place in 2002 and 2004 exactly:
@@ -230,7 +228,9 @@ Holidays.on(Date.civil(2003, 7, 1), :jp)
 
 #### `between`
 
-The 'between' selector will only find a match if the supplied date takes place during the specified range of years. Only a single range of integers representing years is allowed at this time.
+The 'between' selector will only find a match if the supplied date takes place during the specified _inclusive_ range of years.
+
+To use this selector you *must* provide both a `start` and `end` key. Both values must be integers representing years.
 
 Example:
 
@@ -240,16 +240,20 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - between: 1996..2002
+    between:
+      start: 1996
+      end: 2002
 ```
 
-This will return successfully:
+These examples will return successfully since they take place within the specified range:
 
 ```ruby
+Holidays.on(Date.civil(1996, 7, 1), :jp)
 Holidays.on(Date.civil(2000, 7, 1), :jp)
+Holidays.on(Date.civil(2002, 7, 1), :jp)
 ```
 
-This will not:
+These will not since both are outside of the specified start/end range:
 
 ```ruby
 Holidays.on(Date.civil(2003, 7, 1), :jp)

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -114,16 +114,19 @@ Then the holiday will be returned. This is especially useful for holidays like "
 
 ### Year ranges
 
-Certain holidays in various countries are only in effect during specific year ranges. For example, a new holiday might come into effect that is only valid after a specific year (say, 2017).
+Certain holidays in various countries are only in effect during specific year ranges. A few examples of this are:
 
-To address this we have the ability to specify these 'year ranges' in the definition. The gem will then only return a match on a date that adheres to these rules.
+* A new holiday that starts in 2017 and continues into the future
+* An existing holiday that has been cancelled so that the final year in effect is 2019
+* A historical holiday that was only in effect from 2002 through 2006
 
-There are a total of four selectors that can be specified. All must be specified in terms of 'years'.
+To address these kinds of scenarios we have the ability to specify 'year ranges' for individual holiday definitions. There are a total of four selectors that can be specified. All must be specified in terms of 'years'.
 
-#### `before`
+#### `until`
 
-The 'before' selector will only find a match if the supplied date takes place
-before or equal to the holiday.
+The 'until' selector will only return a match if the supplied date takes place in the same year as the holiday or earlier.
+
+A single integer representing a year *must* be supplied. An array of values will result in an error.
 
 Example:
 
@@ -133,28 +136,32 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - before: 2002
+    - until: 2002
 ```
 
-This will return successfully:
+This will return successfully since the date is before 2002:
 
 ```ruby
 Holidays.on(Date.civil(2000, 7, 1), :jp)
 ```
 
-This will not:
+This will also return successfully since the date takes place on 2002 exactly:
+
+```ruby
+Holidays.on(Date.civil(2002, 7, 1), :jp)
+```
+
+This will not since the date is after 2002:
 
 ```ruby
 Holidays.on(Date.civil(2016, 7, 1), :jp)
 ```
 
-#### `after`
+#### `from`
 
+The 'from' selector will only return a match if the supplied date takes place in the same year as the holiday or later.
 
-The 'after' selector will only find a match if the supplied date takes place
-after or equal to the holiday.
-
-A single number *must* be supplied. An array of integers will result in an error.
+A single integer representing a year *must* be supplied. An array of values will result in an error.
 
 Example:
 
@@ -164,16 +171,22 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - after: 2002
+    - from: 2002
 ```
 
-This will return successfully:
+This will return successfully since the date is after 2002:
 
 ```ruby
 Holidays.on(Date.civil(2016, 7, 1), :jp)
 ```
 
-This will not:
+This will also return successfully since the date takes place on 2002 exactly:
+
+```ruby
+Holidays.on(Date.civil(2002, 7, 1), :jp)
+```
+
+This will not since the date is before 2002:
 
 ```ruby
 Holidays.on(Date.civil(2000, 7, 1), :jp)
@@ -184,7 +197,11 @@ Holidays.on(Date.civil(2000, 7, 1), :jp)
 The 'limited' selector will only find a match if the supplied date takes place during
 one of the specified years. Multiple years can be specified.
 
-An array of years *must* be supplied. Individual integers will result in an error.
+An array of integers representing years *must* be supplied. Individual values will result in an error.
+
+Please note that this is *not* a range! This is an array of specific years during which the holiday is active.
+
+If you need a year range please see the `between` selector below.
 
 Example:
 
@@ -194,24 +211,26 @@ Example:
   regions: [jp]
   mday: 1
   year_ranges:
-    - limited: [2002]
+    - limited: [2002,2004]
 ```
 
-This will return successfully:
+Both of these examples will return successfully since the dates takes place in 2002 and 2004 exactly:
 
 ```ruby
 Holidays.on(Date.civil(2002, 7, 1), :jp)
+Holidays.on(Date.civil(2004, 7, 1), :jp)
 ```
 
-This will not:
+Neither of these will return since the dates takes place in outside of 2002 and 2004:
 
 ```ruby
 Holidays.on(Date.civil(2000, 7, 1), :jp)
+Holidays.on(Date.civil(2003, 7, 1), :jp)
 ```
 
 #### `between`
 
-The 'between' selector will only find a match if the supplied date takes place during the specified range of years. Only a single range is allowed at this time.
+The 'between' selector will only find a match if the supplied date takes place during the specified range of years. Only a single range of integers representing years is allowed at this time.
 
 Example:
 

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -12,3 +12,4 @@ Please note that we only began keeping ADRs for this project in October of 2018.
 ## Table of contents
 
  1. [Language specific custom methods](adr-001.md)
+ 1. [Year ranges syntax update](adr-002.md)

--- a/doc/architecture/adr-002.md
+++ b/doc/architecture/adr-002.md
@@ -1,0 +1,50 @@
+# ADR 2: Year ranges syntax update
+
+## Context
+
+#### Original year range behavior
+
+Starting in [v3.2.0](https://github.com/holidays/holidays/releases/tag/v3.2.0) of the ruby gem [\[1\]](#footnote-1) we have had the ability to specify year ranges for specific holidays. This allows for a holiday
+to only be considered 'valid' or 'active' based on specific criteria surrounding years. The available criteria were:
+
+* `before` - holiday only valid if it takes place on the target year or before
+* `after` - holiday only valid if it takes place on the target year or after
+* `limited` - holiday only valid if it takes place on at least one of an array of target years (e.g. [2002, 2004])
+* `between` - holiday only valid if it takes place between an inclusive year range (e.g. 2002..2004)
+
+This change added useful functionality and its use has since spread to multiple regions.
+
+#### Confusion about criteria behavior
+
+On January 24th, 2019 [an issue was opened](https://github.com/holidays/definitions/issues/117) expressing that the `before` and `after` criteria were named in a confusing manner since it was not clear whether they operated inclusively or exclusively on the target year.
+
+As an example, the value `after: 2018` could be construed by some to mean the holiday is valid starting in 2019 and onward. In reality the current implementation is that the holiday is valid starting in 2018 itself and onward.
+
+While this is ultimately up to individual perception the suggested changes it is true that the current names do not provide strong guidance on how the definition will behave.
+
+## Decision
+
+The above issue also contained a proposal that we make the following changes:
+
+* Rename `before` to `until`
+* Rename `after` to `from`
+
+We believe that these names give a clearer understanding of the desired behavior as `until` and `from` are more generally understood to indicate inclusivity rather than exclusivity.
+
+If we take the example from above and make the change then the value `from: 2018` would intend for the holiday to be valid/active starting in 2018 and onward.
+
+## Consequences
+
+This change will require changing multiple files and wll result in a major semantic version bump for the definitionis. In addition we will also need to make a similar breaking change in all consuming apps.
+
+There are mitigating factors, however. There are only a handful of existing definitions that use the `before` or `after` keys and the only consuming app is the [ruby gem](https://github.com/holidays/holidays). This means our affected code is relatively small.
+
+Additionally there was already a plan in place to perform an unrelated breaking change in the gem. This means that we can bundle these breaking changes together and minimize the amount of version churn.
+
+## Status
+
+Accepted.
+
+##### footnote-1
+
+In the original `holidays` ruby library all definitions were housed in the same directory. The definitions were split into a separate repository starting with [holidays gem v5.0.0](https://github.com/holidays/holidays/blob/master/CHANGELOG.md#500).

--- a/doc/architecture/adr-002.md
+++ b/doc/architecture/adr-002.md
@@ -20,22 +20,22 @@ On January 24th, 2019 [an issue was opened](https://github.com/holidays/definiti
 
 As an example, the value `after: 2018` could be construed by some to mean the holiday is valid starting in 2019 and onward. In reality the current implementation is that the holiday is valid starting in 2018 itself and onward.
 
-While this is ultimately up to individual perception the suggested changes it is true that the current names do not provide strong guidance on how the definition will behave.
+While this is ultimately up to individual perception it is true that the current names do not provide strong guidance on how the definition will behave.
 
 ## Decision
 
-The above issue also contained a proposal that we make the following changes:
+The [above issue](https://github.com/holidays/definitions/issues/117) also contained a proposal to make the following changes:
 
 * Rename `before` to `until`
 * Rename `after` to `from`
 
-We believe that these names give a clearer understanding of the desired behavior as `until` and `from` are more generally understood to indicate inclusivity rather than exclusivity.
+These names give a clearer understanding of the desired behavior as `until` and `from` are more generally understood to indicate inclusivity rather than exclusivity.
 
 If we take the example from above and make the change then the value `from: 2018` would intend for the holiday to be valid/active starting in 2018 and onward.
 
 ## Consequences
 
-This change will require changing multiple files and wll result in a major semantic version bump for the definitionis. In addition we will also need to make a similar breaking change in all consuming apps.
+This change will require changing multiple files and wll result in a major semantic version bump for the definitions. In addition we will also need to make a similar breaking change in all consuming apps.
 
 There are mitigating factors, however. There are only a handful of existing definitions that use the `before` or `after` keys and the only consuming app is the [ruby gem](https://github.com/holidays/holidays). This means our affected code is relatively small.
 
@@ -44,6 +44,8 @@ Additionally there was already a plan in place to perform an unrelated breaking 
 ## Status
 
 Accepted.
+
+## Footnotes
 
 ##### footnote-1
 

--- a/doc/architecture/adr-002.md
+++ b/doc/architecture/adr-002.md
@@ -33,11 +33,23 @@ These names give a clearer understanding of the desired behavior as `until` and 
 
 If we take the example from above and make the change then the value `from: 2018` would intend for the holiday to be valid/active starting in 2018 and onward.
 
+#### Additional changes
+
+While looking into the above issue I noticed two important things that will also be addressed alongside the above changes:
+
+* The definition validator does not currently prevent users from specifying multiple selectors at a time for a `year_ranges` entry and we perform no validation that these selectors do not conflict with one another.
+* The `between` key currently accepts a string representation of a Ruby range (e.g. '2008..2012'). While this was not causing any issues today we would like to remove all Ruby-specific values from our definitions so that other languages could more easily parse them.
+
+To that end the following changes will also be made:
+
+* Update the definition validation to only allow a single selector per `year_ranges` entry and update all definitions to match. This will result no behavior changes but will make clear the expected behavior.
+* `between` will no longer accept a ruby-like range string but instead require explicit `start` and `end` keys with integer values representing a year.
+
 ## Consequences
 
 This change will require changing multiple files and wll result in a major semantic version bump for the definitions. In addition we will also need to make a similar breaking change in all consuming apps.
 
-There are mitigating factors, however. There are only a handful of existing definitions that use the `before` or `after` keys and the only consuming app is the [ruby gem](https://github.com/holidays/holidays). This means our affected code is relatively small.
+There are mitigating factors, however. There are only a handful of existing definitions that use the `before`, `after`, or `between` keys and the only consuming app is the [ruby gem](https://github.com/holidays/holidays). This means our affected code is relatively small.
 
 Additionally there was already a plan in place to perform an unrelated breaking change in the gem. This means that we can bundle these breaking changes together and minimize the amount of version churn.
 

--- a/gb.yaml
+++ b/gb.yaml
@@ -3,7 +3,7 @@
 # Including England, Wales, Scotland, N. Ireland, the Isle of Man, Guernsey
 # and Jersey.
 #
-# Updated: 2016-04-29
+# Updated: 2019-02-10
 # Sources:
 # - http://en.wikipedia.org/wiki/List_of_holidays_by_country#United_Kingdom_and_Crown_dependencies
 #
@@ -81,13 +81,13 @@ months:
     type: informal
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - before: 2006
+    - until: 2006
   - name: St. Andrew's Day
     regions: [gb_sct]
     mday: 30
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - after: 2007
+    - from: 2007
   12:
   - name: Christmas Day
     regions: [gb]

--- a/gb.yaml
+++ b/gb.yaml
@@ -81,13 +81,13 @@ months:
     type: informal
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - until: 2006
+      until: 2006
   - name: St. Andrew's Day
     regions: [gb_sct]
     mday: 30
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - from: 2007
+      from: 2007
   12:
   - name: Christmas Day
     regions: [gb]

--- a/jp.yaml
+++ b/jp.yaml
@@ -49,13 +49,13 @@ months:
     regions: [jp]
     mday: 23
     year_ranges:
-      - from: 2020
+      from: 2020
   - name: 振替休日
     regions: [jp]
     mday: 23
     function: jp_substitute_holiday(year, month, day)
     year_ranges:
-      - from: 2020
+      from: 2020
   3:
   - name: 春分の日
     regions: [jp]
@@ -75,18 +75,18 @@ months:
     regions: [jp]
     mday: 30
     year_ranges:
-      - limited: [2019]
+      limited: [2019]
   5:
   - name: 天皇即位
     regions: [jp]
     mday: 1
     year_ranges:
-      - limited: [2019]
+      limited: [2019]
   - name: 休日
     regions: [jp]
     mday: 2
     year_ranges:
-      - limited: [2019]
+      limited: [2019]
   - name: 憲法記念日
     regions: [jp]
     mday: 3
@@ -113,54 +113,62 @@ months:
     regions: [jp]
     mday: 20
     year_ranges:
-      - between: 1996..2002
+      between:
+        start: 1996
+        end: 2002
   - name: 海の日
     regions: [jp]
     wday: 1
     week: 3
     year_ranges:
-      - between: 2003..2019
+      between:
+        start: 2003
+        end: 2019
   - name: 海の日
     regions: [jp]
     mday: 23
     year_ranges:
-      - limited: [2020]
+      limited: [2020]
   - name: 海の日
     regions: [jp]
     wday: 1
     week: 3
     year_ranges:
-      - from: 2021
+      from: 2021
   - name: 振替休日
     regions: [jp]
     function: jp_marine_day_substitute(year)
     year_ranges:
-      - between: 1996..2002
+      between:
+        start: 1996
+        end: 2002
   - name: スポーツの日
     regions: [jp]
     mday: 24
     year_ranges:
-      - limited: [2020]
+      limited: [2020]
   8:
   - name: 山の日
     regions: [jp]
     year_ranges:
-      - between: 2016..2019
+      between:
+        start: 2016
+        end: 2019
     function: jp_mountain_holiday(year)
   - name: 山の日
     regions: [jp]
     mday: 10
     year_ranges:
-      - limited: [2020]
+      limited: [2020]
   - name: 山の日
     regions: [jp]
     year_ranges:
-      - from: 2021
+      from: 2021
     function: jp_mountain_holiday(year)
   - name: 振替休日
     regions: [jp]
     year_ranges:
-      - from: 2016
+      from: 2016
     function: jp_mountain_holiday_substitute(year)
   9:
   - name: 敬老の日
@@ -173,7 +181,7 @@ months:
   - name: 国民の休日
     regions: [jp]
     year_ranges:
-      - from: 2003
+      from: 2003
     function: jp_citizens_holiday(year)
   - name: 秋分の日
     regions: [jp]
@@ -187,13 +195,13 @@ months:
     wday: 1
     week: 2
     year_ranges:
-      - until: 2019
+      until: 2019
   - name: スポーツの日
     regions: [jp]
     wday: 1
     week: 2
     year_ranges:
-      - from: 2021
+      from: 2021
   - name: 振替休日
     regions: [jp]
     function: jp_health_sports_day_substitute(year)
@@ -201,7 +209,7 @@ months:
     regions: [jp]
     mday: 22
     year_ranges:
-      - limited: [2019]
+      limited: [2019]
   11:
   - name: 文化の日
     regions: [jp]
@@ -222,13 +230,13 @@ months:
     regions: [jp]
     mday: 23
     year_ranges:
-      - until: 2018
+      until: 2018
   - name: 振替休日
     regions: [jp]
     mday: 23
     function: jp_substitute_holiday(year, month, day)
     year_ranges:
-      - until: 2018
+      until: 2018
 
 methods:
   jp_health_sports_day_substitute:

--- a/jp.yaml
+++ b/jp.yaml
@@ -16,8 +16,9 @@
 #  2015-05-10: Non-Monday substitute holidays by Shuhei Kagawa <shuhei.kagawa@gmail.com>
 #  2015-12-15: Added mountain day by Tsuyoshi Sano <ttwo32@gmail.com>
 #  2016-03-26: Updated to match new custom method signature. See below for more. Phil Trimble <philtrimble@gmail.com>
+#  2019-02-10: Changing usage of 'year_ranges.after' to 'year_ranges.from' and 'year_ranges.before' to 'year_ranges.until', see https://github.com/holidays/definitions/issues/117
 #
-# NOTE: This is the most complex set of custom date methods in the entire
+# MAINTAINER NOTE: This is the most complex set of custom date methods in the entire
 # project, mainly surrounding the idea of 'substitute' holidays. Since this is
 # the only one that is this complex I have settled on a less-than-ideal solution.
 # It is overly verbose and not easy to follow. It will be a target for refactoring
@@ -48,13 +49,13 @@ months:
     regions: [jp]
     mday: 23
     year_ranges:
-      - after: 2020
+      - from: 2020
   - name: 振替休日
     regions: [jp]
     mday: 23
     function: jp_substitute_holiday(year, month, day)
     year_ranges:
-      - after: 2020
+      - from: 2020
   3:
   - name: 春分の日
     regions: [jp]
@@ -129,7 +130,7 @@ months:
     wday: 1
     week: 3
     year_ranges:
-      - after: 2021
+      - from: 2021
   - name: 振替休日
     regions: [jp]
     function: jp_marine_day_substitute(year)
@@ -154,12 +155,12 @@ months:
   - name: 山の日
     regions: [jp]
     year_ranges:
-      - after: 2021
+      - from: 2021
     function: jp_mountain_holiday(year)
   - name: 振替休日
     regions: [jp]
     year_ranges:
-      - after: 2016
+      - from: 2016
     function: jp_mountain_holiday_substitute(year)
   9:
   - name: 敬老の日
@@ -172,7 +173,7 @@ months:
   - name: 国民の休日
     regions: [jp]
     year_ranges:
-      - after: 2003
+      - from: 2003
     function: jp_citizens_holiday(year)
   - name: 秋分の日
     regions: [jp]
@@ -186,13 +187,13 @@ months:
     wday: 1
     week: 2
     year_ranges:
-      - before: 2019
+      - until: 2019
   - name: スポーツの日
     regions: [jp]
     wday: 1
     week: 2
     year_ranges:
-      - after: 2021
+      - from: 2021
   - name: 振替休日
     regions: [jp]
     function: jp_health_sports_day_substitute(year)
@@ -221,13 +222,13 @@ months:
     regions: [jp]
     mday: 23
     year_ranges:
-      - before: 2018
+      - until: 2018
   - name: 振替休日
     regions: [jp]
     mday: 23
     function: jp_substitute_holiday(year, month, day)
     year_ranges:
-      - before: 2018
+      - until: 2018
 
 methods:
   jp_health_sports_day_substitute:

--- a/lib/validation/month_validator.rb
+++ b/lib/validation/month_validator.rb
@@ -22,11 +22,13 @@ module Definitions
             if month_def.key?("year_ranges")
               month_def["year_ranges"].each do |yr|
                 yr.each_pair do |k, v|
-                  raise Errors::InvalidMonth.new("The :year_ranges value only accepts the following: :before, :after, :limited, :between, received: #{months}") unless [:before, :after, :limited, :between].include?(k.to_sym)
+                  raise Errors::InvalidMonth.new("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}") unless [:until, :from, :limited, :between].include?(k.to_sym)
 
                   case k
-                  when "after"
-                    raise Errors::InvalidMonth.new("The year_ranges.after value must contain a single 'year' integer, ex. 2018, received: #{months}") unless v.is_a?(Integer)
+                  when "until"
+                    raise Errors::InvalidMonth.new("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}") unless v.is_a?(Integer)
+                  when "from"
+                    raise Errors::InvalidMonth.new("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}") unless v.is_a?(Integer)
                   when "limited"
                     raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless v.is_a?(Array)
 

--- a/lib/validation/month_validator.rb
+++ b/lib/validation/month_validator.rb
@@ -20,23 +20,32 @@ module Definitions
             end
 
             if month_def.key?("year_ranges")
-              month_def["year_ranges"].each do |yr|
-                yr.each_pair do |k, v|
-                  raise Errors::InvalidMonth.new("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}") unless [:until, :from, :limited, :between].include?(k.to_sym)
+              raise Errors::InvalidMonth.new("year_ranges only supports a single selector at this time, received: #{months}") unless month_def["year_ranges"].is_a?(Hash) && month_def["year_ranges"].size == 1
 
-                  case k
-                  when "until"
-                    raise Errors::InvalidMonth.new("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}") unless v.is_a?(Integer)
-                  when "from"
-                    raise Errors::InvalidMonth.new("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}") unless v.is_a?(Integer)
-                  when "limited"
-                    raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless v.is_a?(Array)
+              selector = month_def["year_ranges"].keys.first
+              value = month_def["year_ranges"][selector]
 
-                    v.each do |j|
-                     raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless j.is_a?(Integer)
-                    end
-                  end
+              raise Errors::InvalidMonth.new("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}") unless [:until, :from, :limited, :between].include?(selector.to_sym)
+
+              case selector
+              when "until"
+                raise Errors::InvalidMonth.new("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value.is_a?(Integer)
+              when "from"
+                raise Errors::InvalidMonth.new("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value.is_a?(Integer)
+              when "limited"
+                raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless value.is_a?(Array)
+
+                value.each do |j|
+                  raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless j.is_a?(Integer)
                 end
+              when "between"
+                raise Errors::InvalidMonth.new("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}") unless value.is_a?(Hash) && value.key?("start") && value.key?("end")
+
+                raise Errors::InvalidMonth.new("The year_ranges.between.start value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value["start"].is_a?(Integer)
+                raise Errors::InvalidMonth.new("The year_ranges.between.end value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value["end"].is_a?(Integer)
+
+                raise Errors::InvalidMonth.new("The year_ranges.between.end value cannot be before the start value, received: #{months}") if value["end"] < value["start"]
+                raise Errors::InvalidMonth.new("The year_ranges.between start and end values cannot be the same, received: #{months}") if value["end"] == value["start"]
               end
             end
           end

--- a/ro.yaml
+++ b/ro.yaml
@@ -22,7 +22,7 @@ months:
     function: orthodox_easter(year)
     function_modifier: -2
     year_ranges:
-      - after: 2018
+     from: 2018
   - name: Paștele - duminică
     regions: [ro]
     function: orthodox_easter(year)
@@ -49,7 +49,7 @@ months:
     regions: [ro]
     mday: 24
     year_ranges:
-      - after: 2017
+      from: 2017
   5:
   - name: Ziua muncii
     regions: [ro]
@@ -59,7 +59,7 @@ months:
     regions: [ro]
     mday: 1
     year_ranges:
-      - after: 2017
+     from: 2017
   8:
   - name: Adormirea Maicii Domnului
     regions: [ro]

--- a/spec/validation/month_validator_spec.rb
+++ b/spec/validation/month_validator_spec.rb
@@ -68,32 +68,41 @@ describe Definitions::Validation::Month do
       }
     end
 
-    it 'returns error if year_ranges contains unknown subkey' do
-      months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"blah" => [2018]}] }] }
-      expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("The :year_ranges value only accepts the following: :before, :after, :limited, :between, received: #{months}")
-      }
-    end
+    context 'year_ranges' do
+      it 'returns error if year_ranges contains unknown subkey' do
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"blah" => [2018]}] }] }
+        expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+          expect(e.message).to eq("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}")
+        }
+      end
 
-    it 'returns error if :after value is not a single integer' do
-      months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"after" => [2018]}] }] }
-      expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("The year_ranges.after value must contain a single 'year' integer, ex. 2018, received: #{months}")
-      }
-    end
+      it 'returns error if :until value is not a single integer' do
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"until" => [2018]}] }] }
+        expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+          expect(e.message).to eq("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}")
+        }
+      end
 
-    it 'returns error if :limited value is not an array' do
-      months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => 2018}] }] }
-      expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
-      }
-    end
+      it 'returns error if :from value is not a single integer' do
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"from" => [2018]}] }] }
+        expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+          expect(e.message).to eq("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}")
+        }
+      end
 
-    it 'returns error if :limited value is not an array of integers' do
-      months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => ["blah"]}] }] }
-      expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
-      }
+      it 'returns error if :limited value is not an array' do
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => 2018}] }] }
+        expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+          expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
+        }
+      end
+
+      it 'returns error if :limited value is not an array of integers' do
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => ["blah"]}] }] }
+        expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+          expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
+        }
+      end
     end
   end
 end

--- a/spec/validation/month_validator_spec.rb
+++ b/spec/validation/month_validator_spec.rb
@@ -70,38 +70,105 @@ describe Definitions::Validation::Month do
 
     context 'year_ranges' do
       it 'returns error if year_ranges contains unknown subkey' do
-        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"blah" => [2018]}] }] }
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"blah" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
           expect(e.message).to eq("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}")
         }
       end
 
       it 'returns error if :until value is not a single integer' do
-        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"until" => [2018]}] }] }
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"until" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
           expect(e.message).to eq("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}")
         }
       end
 
       it 'returns error if :from value is not a single integer' do
-        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"from" => [2018]}] }] }
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"from" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
           expect(e.message).to eq("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}")
         }
       end
 
       it 'returns error if :limited value is not an array' do
-        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => 2018}] }] }
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"limited" => 2018} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
           expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
         }
       end
 
       it 'returns error if :limited value is not an array of integers' do
-        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"limited" => ["blah"]}] }] }
+        months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"limited" => ["blah"]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
           expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
         }
+      end
+
+      context 'between' do
+        it 'returns error if not a hash' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => "2008..2012" } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+          }
+        end
+
+        it 'returns error if start is missing' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"end" => 2018} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+          }
+        end
+
+        it 'returns error if end is missing' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+          }
+        end
+
+        it 'returns an error if start value is not an integer' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => "2016", "end" => 2018} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("The year_ranges.between.start value must contain a single 'year' integer, ex. 2018, received: #{months}")
+          }
+        end
+
+        it 'returns an error if end value is not an integer' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => "2018"} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("The year_ranges.between.end value must contain a single 'year' integer, ex. 2018, received: #{months}")
+          }
+        end
+
+        it 'returns an error if end value is before start' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => 2015} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("The year_ranges.between.end value cannot be before the start value, received: #{months}")
+          }
+        end
+
+        it 'returns an error if the start and end values are the same' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => 2016} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("The year_ranges.between start and end values cannot be the same, received: #{months}")
+          }
+        end
+      end
+
+      context 'with multiple selectors' do
+        it 'returns an error if provided an array' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"from" => 2019}, {"between" => {"start" => 2014, "end" => 2016} }] }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("year_ranges only supports a single selector at this time, received: #{months}")
+          }
+        end
+
+        it 'returns an error if there is more than 1 sub key' do
+          months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"from" => 2019, "between" => {"start" => 2014, "end" => 2016} } }] }
+          expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
+            expect(e.message).to eq("year_ranges only supports a single selector at this time, received: #{months}")
+          }
+        end
       end
     end
   end

--- a/tr.yaml
+++ b/tr.yaml
@@ -64,7 +64,7 @@ months:
     regions: [tr]
     mday: 15
     year_ranges:
-    - from: 2016
+      from: 2016
   8:
   - name: Zafer Bayramı # Victory Day
     regions: [tr]

--- a/tr.yaml
+++ b/tr.yaml
@@ -1,6 +1,6 @@
 # Turkish holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2017-06-14
+# Updated: 2019-02-10
 #
 # Note:
 # This holiday definition file contains pre-defined dates
@@ -64,7 +64,7 @@ months:
     regions: [tr]
     mday: 15
     year_ranges:
-    - after: 2016
+    - from: 2016
   8:
   - name: Zafer Bayramı # Victory Day
     regions: [tr]

--- a/ua.yaml
+++ b/ua.yaml
@@ -39,7 +39,7 @@ months:
     regions: [ua]
     mday: 2
     year_ranges:
-    - until: 2017
+      until: 2017
   - name: День перемоги над нацизмом у Другій світовій війні # Victory day over Nazism in World War II
     regions: [ua]
     mday: 9
@@ -50,34 +50,34 @@ months:
     mday: 28
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - from: 1997
+      from: 1997
   7:
   - name: День Незалежності України # Independence Day
     regions: [ua]
     mday: 16
     year_ranges:
-    - limited: [1991]
+      limited: [1991]
   8:
   - name: День Незалежності # Independence Day
     regions: [ua]
     mday: 24
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - from: 1992
+      from: 1992
   10:
   - name: День захисника України # Defender of Ukraine Day
     regions: [ua]
     mday: 14
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - from: 2015
+      from: 2015
   12:
   - name: Різдво Христове # (Gregorian and Revised Julian) Christmas
     regions: [ua]
     mday: 25
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - from: 2017
+      from: 2017
 
 tests:
 - given:

--- a/ua.yaml
+++ b/ua.yaml
@@ -1,6 +1,6 @@
 # Ukrainian holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2018-11-22.
+# Updated: 2019-02-10.
 # Sources:
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Ukraine
 # - https://uk.wikipedia.org/wiki/%D0%9D%D0%B5%D1%80%D0%BE%D0%B1%D0%BE%D1%87%D1%96_%D0%B4%D0%BD%D1%96_%D0%B2_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%96
@@ -39,7 +39,7 @@ months:
     regions: [ua]
     mday: 2
     year_ranges:
-    - before: 2017
+    - until: 2017
   - name: День перемоги над нацизмом у Другій світовій війні # Victory day over Nazism in World War II
     regions: [ua]
     mday: 9
@@ -50,7 +50,7 @@ months:
     mday: 28
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - after: 1997
+    - from: 1997
   7:
   - name: День Незалежності України # Independence Day
     regions: [ua]
@@ -63,21 +63,21 @@ months:
     mday: 24
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - after: 1992
+    - from: 1992
   10:
   - name: День захисника України # Defender of Ukraine Day
     regions: [ua]
     mday: 14
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - after: 2015
+    - from: 2015
   12:
   - name: Різдво Христове # (Gregorian and Revised Julian) Christmas
     regions: [ua]
     mday: 25
     observed: to_monday_if_weekend(date)
     year_ranges:
-    - after: 2017
+    - from: 2017
 
 tests:
 - given:


### PR DESCRIPTION
Addresses https://github.com/holidays/definitions/issues/117 and make updates to other `year_ranges` related behavior as listed below. This is a breaking change and will require a major semver bump. All consumers will be required to update to consume these latest definitions or they will see errors.

## Rename `:before` and `:after` keys

Renames the existing :year_ranges keys :before and :after to :until and :from, respectively. This is done so that the desired behavior of inclusivity is more clearly specified.

Example: a holiday should be valid up to and including 2002:
  Old syntax - 'before: 2002'
  New syntax - 'until: 2002

## Restrict `:year_ranges` to a single key at a time

Currently we allow for multiple keys to be specified for each `:year_ranges` entry but we perform no validation that the selectors do not conflict with one another. This PR now validates that only a single selector is used. No definitions use multiple selectors today but the definitions have been updated to make it more clear that only a single key is allowed.

## Update `:between` key to require explicit `start` and `end` keys rather than accepting ruby range

Currently definitions using the `between` key provide a string representing a ruby range (e.g. `2008..2012`). In order to remove any ruby-specific values from our definitions we will now require an explicit `start` and `end` key. Definitions using `between` have been updated to reflect this.

Also tagging @iGEL for review (I don't like that github won't allow me to add reviewers from outside the organization! Am I missing a setting somewhere to allow this? 🤔 )