### PR TITLE
Christmas is observed on nearest weekday

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -184,7 +184,7 @@ months:
   - name: Christmas Day
     regions: [ca]
     mday: 25
-    observed: to_monday_if_weekend(date)
+    observed: to_weekday_if_weekend(date)
   - name: Boxing Day
     regions: [ca_on]
     mday: 26
@@ -751,6 +751,12 @@ tests:
       name: "Christmas Day"
   - given:
       date: '2016-12-26'
+      regions: ["ca"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2021-12-24'
       regions: ["ca"]
       options: ["observed"]
     expect:

--- a/us.yaml
+++ b/us.yaml
@@ -304,7 +304,7 @@ months:
   - name: Christmas Day
     regions: [us]
     mday: 25
-    observed: to_monday_if_weekend(date)
+    observed: to_weekday_if_weekend(date)
   - name: Day after Christmas
     regions: [us_ar, us_nc, us_ok, us_sc, us_tn, us_tx]
     mday: 26
@@ -935,7 +935,7 @@ tests:
     expect:
       holiday: false
   - given:
-      date: ['2021-12-27', '2022-12-26', '2027-12-27']
+      date: ['2021-12-24', '2022-12-26', '2027-12-24']
       regions: ["us"]
       options: ["observed"]
     expect:


### PR DESCRIPTION
Christmas is observed on nearest weekday rather than the next Monday if it falls on a weekend. I suspect some other definitions will need updating.