### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,14 @@ notifications:
     holidaysgem@gmail.com
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
+  - ruby-head
+  - jruby-9.2.6.0
   - jruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head


### PR DESCRIPTION
* Drop support for cruby 2.3
* Add support for cruby 2.6
* Update jruby-9.2.6.0
* Update to latest patch for all versions
* Allow failures for ruby-head and jruby-head