### PR TITLE
Move May Day in 2020

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -47,6 +47,19 @@ months:
     regions: [gb]
     week: 1
     wday: 1
+    year_ranges:
+      until: 2019
+  - name: May Day 
+    regions: [gb]
+    mday: 8
+    year_ranges:
+      limited: [2020]
+  - name: May Day
+    regions: [gb]
+    week: 1
+    wday: 1
+    year_ranges:
+      from: 2021
   - name: Liberation Day
     regions: [je, gb_jsy, gg, gb_gsy]
     mday: 9


### PR DESCRIPTION
The UK government moved the may bank holiday to another day for the year 2020: 

https://www.gov.uk/government/news/2020-may-bank-holiday-will-be-moved-to-mark-75th-anniversary-of-ve-day