### PR TITLE
IT: Add venetian patron's feasts

### DIFF
--- a/it.yaml
+++ b/it.yaml
@@ -19,6 +19,12 @@
 # - add Festa di San Giovanni Battista for it_fi, it_ge, it_to regions
 # Sources:
 # - https://www.officeholidays.com/holidays/italy/st-johns-day
+#
+# Changes 2019-09-18
+# - add Venetian regions (it_vr, it_vi, it_pd, it_ro, it_tv, it_bl, it_ve)
+# - add patron's feast for each venetian region
+# Sources:
+# - https://it.wikipedia.org/wiki/Santi_patroni_cattolici_delle_citt%C3%A0_capoluogo_di_provincia_italiane
 ---
 months:
   0:
@@ -40,28 +46,50 @@ months:
   - name: Festa della Liberazione
     regions: [it]
     mday: 25
+  - name: Festa di San Marco Evangelista
+    regions: [it_ve]
+    mday: 25
+  - name: Festa di San Liberale
+    regions: [it_tv]
+    mday: 27
   5:
   - name: Festa dei Lavoratori
     regions: [it]
-    mday: 1
+    mday: 1  
+  - name: Festa di San Zeno
+    regions: [it_vr]
+    mday: 21 
   6:
   - name: Festa della Repubblica
     regions: [it]
     mday: 2
+  - name: Festa di Sant'Antonio di Padova
+    regions: [it_pd]
+    mday: 13    
   - name: Festa di San Giovanni Battista
     regions: [it_fi, it_ge, it_to]
     mday: 24
   - name: Festa di San Pietro e Paolo
     regions: [it_rm]
     mday: 29
-  8:
+  8:  
   - name: Assunzione
     regions: [it]
     mday: 15
+  9:  
+  - name: Festa della Madonna di Monte Berico
+    regions: [it_vi]
+    mday: 8    
   11:
   - name: Ognissanti
     regions: [it]
     mday: 1
+  - name: Festa di San Martino
+    regions: [it_bl]
+    mday: 11
+  - name: Festa di San Bellino
+    regions: [it_ro]
+    mday: 26
   12:
   - name: Immacolata Concezione
     regions: [it]
@@ -105,17 +133,41 @@ tests:
     expect:
       name: "Festa della Liberazione"
   - given:
+      date: '2019-04-25'
+      regions: ["it_ve"]
+      options: ["informal"]
+    expect:
+      name: "Festa di San Marco Evangelista"
+  - given:
+      date: '2019-04-27'
+      regions: ["it_tv"]
+      options: ["informal"]
+    expect:
+      name: "Festa di San Liberale"
+  - given:
       date: '2007-05-01'
       regions: ["it"]
       options: ["informal"]
     expect:
       name: "Festa dei Lavoratori"
   - given:
+      date: '2019-05-21'
+      regions: ["it_vr"]
+      options: ["informal"]
+    expect:
+      name: "Festa di San Zeno"
+  - given:
       date: '2007-06-02'
       regions: ["it"]
       options: ["informal"]
     expect:
       name: "Festa della Repubblica"
+  - given:
+      date: '2019-06-13'
+      regions: ["it_pd"]
+      options: ["informal"]
+    expect:
+      name: "Festa di Sant'Antonio di Padova"
   - given:
       date: '2019-06-24'
       regions: ["it_fi", "it_ge", "it_to"]
@@ -145,11 +197,29 @@ tests:
     expect:
       name: "Assunzione"
   - given:
+      date: '2019-09-08'
+      regions: ["it_vi"]
+      options: ["informal"]
+    expect:
+      name: "Festa della Madonna di Monte Berico"
+  - given:
       date: '2007-11-01'
       regions: ["it"]
       options: ["informal"]
     expect:
       name: "Ognissanti"
+  - given:
+      date: '2019-11-11'
+      regions: ["it_bl"]
+      options: ["informal"]
+    expect:
+      name: "Festa di San Martino"
+  - given:
+      date: '2019-11-26'
+      regions: ["it_ro"]
+      options: ["informal"]
+    expect:
+      name: "Festa di San Bellino"
   - given:
       date: '2007-12-08'
       regions: ["it"]


### PR DESCRIPTION
For each Venetian region of Italy (Venice `it_ve`, Verona `it_vr`, Vicenza `it_vi`, Padova `it_pd`, Treviso `it_tv`, Belluno `it_bl`, Rovigo `it_ro`) add pertinent patron's feast.

[[IT] Italian patron's feasts list by city ](https://it.wikipedia.org/wiki/Santi_patroni_cattolici_delle_citt%C3%A0_capoluogo_di_provincia_italiane)