### PR TITLE
Add Québec to provinces observing Canadian Thanksgiving

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -174,7 +174,7 @@ months:
   10:
   - name: Thanksgiving
     week: 2
-    regions: [ca_ab, ca_bc, ca_mb, ca_nt, ca_nu, ca_on, ca_sk, ca_yt]
+    regions: [ca_ab, ca_bc, ca_mb, ca_nt, ca_nu, ca_on, ca_qc, ca_sk, ca_yt]
     wday: 1
   11:
   - name: Remembrance Day


### PR DESCRIPTION
See “The 2nd Monday in October (Thanksgiving)” listed on https://www.cnt.gouv.qc.ca/en/leaves-and-absences/statutory-holidays/index.html