### PR TITLE
Add May 1 and May 9 holidays for Luxembourg

### DIFF
--- a/lu.yaml
+++ b/lu.yaml
@@ -29,6 +29,8 @@ months:
   - name: Europadag
     regions: [lu]
     mday: 9
+    year_ranges:
+      from: 2019
   6:
   - name: Nationalfeierdag
     regions: [lu]
@@ -104,3 +106,18 @@ tests:
       options: ["informal"]
     expect:
       name: "Péngschtméindeg"
+  - given:
+      date: '2019-05-01'
+      regions: ["lu"]
+    expect:
+      name: "Dag vun der Aarbecht"
+  - given:
+      date: '2019-05-09'
+      regions: ["lu"]
+    expect:
+      name: "Europadag"
+  - given:
+      date: '2018-05-09'
+      regions: ["lu"]
+    expect:
+      holiday: false

--- a/lu.yaml
+++ b/lu.yaml
@@ -1,6 +1,6 @@
 # Luxembourg holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2019-07-19.
+# Updated: 2020-01-21.
 # Sources:
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg
 ---
@@ -22,6 +22,13 @@ months:
   - name: Neijoerschdag
     regions: [lu]
     mday: 1
+  5:
+  - name: Dag vun der Aarbecht
+    regions: [lu]
+    mday: 1
+  - name: Europadag
+    regions: [lu]
+    mday: 9
   6:
   - name: Nationalfeierdag
     regions: [lu]


### PR DESCRIPTION
Updated based on https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg

This addresses https://github.com/holidays/holidays/issues/288