### PR TITLE
Add Ramadan & Sacrafice holidays in 2020

### DIFF
--- a/tr.yaml
+++ b/tr.yaml
@@ -84,7 +84,8 @@ methods:
           '2016' => Date.civil(2016, 7, 5),
           '2017' => Date.civil(2017, 6, 25),
           '2018' => Date.civil(2018, 6, 15),
-          '2019' => Date.civil(2019, 6, 4)
+          '2019' => Date.civil(2019, 6, 4),
+          '2020' => Date.civil(2020, 5, 24)
       }
       begin_of_ramadan_feast[year.to_s]
   sacrifice_feast:
@@ -96,7 +97,8 @@ methods:
           '2016' => Date.civil(2016, 9, 12),
           '2017' => Date.civil(2017, 9, 1),
           '2018' => Date.civil(2018, 8, 21),
-          '2019' => Date.civil(2019, 8, 11)
+          '2019' => Date.civil(2019, 8, 11),
+          '2020' => Date.civil(2020, 7, 31)
       }
       begin_of_sacrifice_feast[year.to_s]
 tests:
@@ -131,17 +133,17 @@ tests:
     expect:
       name: "Cumhuriyet Bayramı"
   - given:
-      date: ['2017-6-25', '2018-6-15', '2019-6-4']
+      date: ['2017-6-25', '2018-6-15', '2019-6-4', '2020-5-24']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı"
   - given:
-      date: ['2017-6-26', '2018-6-16', '2019-6-5']
+      date: ['2017-6-26', '2018-6-16', '2019-6-5', '2020-5-25']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-6-27', '2018-6-17', '2019-6-6']
+      date: ['2017-6-27', '2018-6-17', '2019-6-6', '2020-5-26']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (üçüncü tatil)"
@@ -151,22 +153,22 @@ tests:
     expect:
       name: "Demokrasi ve Milli Birlik Günü"
   - given:
-      date: ['2017-9-1', '2018-8-21', '2019-8-11']
+      date: ['2017-9-1', '2018-8-21', '2019-8-11', '2020-7-31']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı"
   - given:
-      date: ['2017-9-2', '2018-8-22', '2019-8-12']
+      date: ['2017-9-2', '2018-8-22', '2019-8-12', '2020-8-01']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-9-3', '2018-8-23', '2019-8-13']
+      date: ['2017-9-3', '2018-8-23', '2019-8-13', '2020-8-02']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (üçüncü tatil)"
   - given:
-      date: ['2017-9-4', '2018-8-24', '2019-8-14']
+      date: ['2017-9-4', '2018-8-24', '2019-8-14', '2020-8-03']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (dördüncü tatil)"


### PR DESCRIPTION
Hello everyone. I have updated Ramadan and Sacrifice holiday dates since they are shifting each year. 

There are many resources for validating these dates but most of them are Turkish. [This website](https://www.officeholidays.com/countries/turkey/2020) is appearing in the search result as a first item. You could check it or any other website for validation.

Please let me know if PR is against contribution rules. Thank you
