### PR TITLE
Add Nigerian Holidays

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -75,3 +75,4 @@ defs:
   SG: ['sg.yaml']
   MY: ['my.yaml']
   TH: ['th.yaml']
+  NG: ['ng.yaml']

--- a/ng.yaml
+++ b/ng.yaml
@@ -1,0 +1,97 @@
+# Nigeria holiday definitions for the Ruby Holiday gem.
+# Updated: 2020-04-28
+# Sources:
+# - https://en.wikipedia.org/wiki/Public_holidays_in_Nigeria
+---
+months:
+  0:
+    - name: Good Friday
+      regions: [ng]
+      function: easter(year)
+      function_modifier: -2
+    - name: Easter Monday
+      regions: [ng]
+      function: easter(year)
+      function_modifier: 1
+  1:
+  - name: New Year's Day
+    regions: [ng]
+    mday: 1
+    observed: to_monday_if_weekend(date)
+  5:
+  - name: Workers' Day
+    regions: [ng]
+    mday: 1
+    observed: to_monday_if_weekend(date)
+  - name: Children's Day
+    regions: [ng]
+    mday: 27
+    type: informal
+  6:
+  - name: Democracy Day
+    regions: [ng]
+    mday: 12
+    year_ranges:
+      from: 2018
+  10:
+  - name: Independence Day
+    regions: [ng]
+    mday: 1
+    observed: to_monday_if_weekend(date)
+  12:
+  - name: Christmas Day
+    regions: [ng]
+    mday: 25
+    observed: to_monday_if_weekend(date)
+  - name: Boxing Day
+    regions: [ng]
+    mday: 26
+    observed: to_weekday_if_boxing_weekend(date)
+
+tests:
+  - given:
+      date: '2008-03-21'
+      regions: ["ng"]
+    expect:
+      name: "Good Friday"
+  - given:
+      date: '2008-03-24'
+      regions: ["ng"]
+    expect:
+      name: "Easter Monday"
+  - given:
+      date: '2008-01-01'
+      regions: ["ng"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2008-05-05'
+      regions: ["ng"]
+    expect:
+      name: "Workers' Day"
+  - given:
+      date: '2008-05-27'
+      regions: ["ng"]
+      options: ["informal"]
+    expect:
+      name: "Children's Day"
+  - given:
+      date: '2019-06-12'
+      regions: ["ng"]
+    expect:
+      name: "Democracy Day"
+  - given:
+      date: '2008-10-01'
+      regions: ["ng"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: '2008-12-25'
+      regions: ["ng"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2008-12-26'
+      regions: ["ng"]
+    expect:
+      name: "Boxing Day"


### PR DESCRIPTION
Hello everyone,

Adding the initial and minimum Nigerian holidays so Nigeria can be used in the gem. These holidays can be confirmed here: [Public Holidays in Nigeria - Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_Nigeria).

Please let me know if I need to change anything or update anything, or if my PR is against contribution rules. I hope to include the Ramadan holidays in Nigeria next once this PR is accepted, so I am sure I am on the right track.

Cheers!