### PR TITLE
Correcting observed Battle of the Boyne, N.Ireland (Problem occurs July 2020)

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -49,7 +49,7 @@ months:
     wday: 1
     year_ranges:
       until: 2019
-  - name: May Day 
+  - name: May Day
     regions: [gb]
     mday: 8
     year_ranges:
@@ -74,6 +74,7 @@ months:
   - name: Battle of the Boyne
     regions: [gb_nir]
     mday: 12
+    observed: to_monday_if_weekend(date)
   8:
   - name: Bank Holiday
     regions: [gb_sct]
@@ -184,6 +185,51 @@ tests:
       options: ["observed", "informal"]
     expect:
       name: "St. Patrick's Day"
+  - given:
+      date: '2020-07-12'
+      regions: ["gb_nir"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2020-07-12'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: '2020-07-13'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2008-07-12'
+      regions: ["gb_nir"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2008-07-14'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2021-07-12'
+      regions: ["gb_nir"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2021-07-12'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Battle of the Boyne"
+  - given:
+      date: '2021-07-13'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      holiday: false
   - given:
       date: '2006-11-30'
       regions: ["gb_sct"]


### PR DESCRIPTION
The observed public holiday in Northern Ireland for the 12th July,
"Battle of the Boyne", also called "Orangemen's Day", takes place
on the following Monday if it falls on the weekend.

From: https://www.nidirect.gov.uk/articles/bank-holidays
"When the usual date falls on a Saturday or Sunday, the
'substitute day' is normally the following Monday."

The examples given on the web page are:
Battle of the Boyne / Orangemen's Day, 13 July 2020, 12 July 2021