### PR TITLE
Add 2021 jp holiday

### DIFF
--- a/jp.yaml
+++ b/jp.yaml
@@ -174,8 +174,7 @@ months:
     regions: [jp]
     mday: 8
     year_ranges:
-      from: 2021
-    function: jp_mountain_holiday(year)
+      limited: [2021]
   - name: 山の日
     regions: [jp]
     year_ranges:
@@ -184,7 +183,19 @@ months:
   - name: 振替休日
     regions: [jp]
     year_ranges:
-      from: 2016
+      between:
+        start: 2016
+        end: 2020
+    function: jp_mountain_holiday_substitute(year)
+  - name: 振替休日
+    regions: [jp]
+    mday: 9
+    year_ranges:
+      limited: [2021]
+  - name: 振替休日
+    regions: [jp]
+    year_ranges:
+      from: 2022
     function: jp_mountain_holiday_substitute(year)
   9:
   - name: 敬老の日

--- a/jp.yaml
+++ b/jp.yaml
@@ -131,10 +131,15 @@ months:
       limited: [2020]
   - name: 海の日
     regions: [jp]
+    mday: 22
+    year_ranges:
+      limited: [2021]
+  - name: 海の日
+    regions: [jp]
     wday: 1
     week: 3
     year_ranges:
-      from: 2021
+      from: 2022
   - name: 振替休日
     regions: [jp]
     function: jp_marine_day_substitute(year)
@@ -142,6 +147,11 @@ months:
       between:
         start: 1996
         end: 2002
+  - name: スポーツの日
+    regions: [jp]
+    mday: 23
+    year_ranges:
+      limited: [2021]
   - name: スポーツの日
     regions: [jp]
     mday: 24
@@ -162,8 +172,14 @@ months:
       limited: [2020]
   - name: 山の日
     regions: [jp]
+    mday: 8
     year_ranges:
       from: 2021
+    function: jp_mountain_holiday(year)
+  - name: 山の日
+    regions: [jp]
+    year_ranges:
+      from: 2022
     function: jp_mountain_holiday(year)
   - name: 振替休日
     regions: [jp]


### PR DESCRIPTION
I have registered Japan's holidays in 2021.

The result created from this definition file is https://github.com/holidays/holidays/pull/373 for the https://github.com/holidays/holidays.

The correctness of the definition file is confirmed in the https://github.com/holidays/holidays/pull/373 to the holidays repository.