### PR TITLE
fix(za): Boxing day does not roll over to Monday if on Saturday

### DIFF
--- a/za.yaml
+++ b/za.yaml
@@ -62,7 +62,7 @@ months:
   - name: Day of Goodwill
     regions: [za]
     mday: 26
-    observed: to_weekday_if_boxing_weekend(date)
+    observed: to_monday_if_sunday(date)
 
 tests:
   - given:


### PR DESCRIPTION
All public holiday falling on a Sunday in South Africa(ZA), the Monday following on it shall be a public holiday.

https://www.gov.za/about-sa/public-holidays