### PR TITLE
FIX: tasmania / nsw / vic do not observe on Monday

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -71,7 +71,7 @@ months:
     regions: [au]
     mday: 25
   - name: ANZAC Day
-    regions: [au_nsw, au_vic, au_qld, au_nt, au_act, au_sa, au_tas]
+    regions: [au_qld, au_nt, au_act, au_sa]
     mday: 25
     observed: to_monday_if_sunday(date)
   - name: ANZAC Day


### PR DESCRIPTION
https://worksafe.tas.gov.au/topics/laws-and-compliance/public-holidays
https://www.nsw.gov.au/living-nsw/school-and-public-holidays
https://business.vic.gov.au/business-information/public-holidays/victorian-public-holidays-2021
