### PR TITLE
Add the Queen's platinum jubilee

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -456,3 +456,13 @@ tests:
       regions: ["je"]
     expect:
       name: "Bank Holiday"
+  - given:
+      date: '2022-06-02'
+      regions: ["gb_"]
+    expect:
+      name: "Bank Holiday"
+  - given:
+      date: '2022-06-03'
+      regions: ["gb_"]
+    expect:
+      name: "Bank Holiday"


### PR DESCRIPTION
This is for the wonderous news of the Queen's platinum jubilee: https://www.bbc.co.uk/news/uk-54911550

This has been confirmed by the UK Gov site: https://www.gov.uk/bank-holidays

![image](https://user-images.githubusercontent.com/299102/132060918-6be36080-89dd-4477-9c4a-2461b979a98d.png)

Unfortunately I am struggling to make this change.

I have added what I think are two tests for the new dates. NB, another date (the late May bank holiday) has been delayed to form one of these new dates. 

So, using TDD, I would expect this change as-is to fail twice with the two new tests. Ultimately I would hope to make it fail at least 3 times (including the move of the previous holiday) before I even started on adding the new definitions.

But running the following, everything passes fine:

```bash
git clone git@github.com:holidays/holidays.git
cd holidays
bundle install
BRANCH=add-queens-jubilee USER=hlascelles make point-to-defs-branch
make test
# Passes!
```

To the best of my knowledge that is what I have been asked to check. I must confess I find the submission process hard to follow. Why is everything passing?

More generally, the barrier to entry for submissions is quite high. I know this has been discussed before, and my 2 cents is that it could be easier...

Any guidance appreciated!