### PR TITLE
Add Juneteenth to `federalreservebanks` region

### DIFF
--- a/federalreservebanks.yaml
+++ b/federalreservebanks.yaml
@@ -29,6 +29,13 @@ months:
     week: -1
     wday: 1
     regions: [federalreservebanks]
+  6:
+  - name: Juneteenth National Independence Day
+    regions: [federalreservebanks]
+    mday: 19
+    observed: to_weekday_if_weekend(date)
+    year_ranges:
+      from: 2021
   7:
   - name: Independence Day
     regions: [federalreservebanks]
@@ -84,6 +91,18 @@ tests:
       options: ["observed"]
     expect:
       name: "Memorial Day"
+  - given:
+      date: ['2021-06-19']
+      regions: ["federalreservebanks"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2021-06-18']
+      regions: ["federalreservebanks"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
   - given:
       date: '2012-07-04'
       regions: ["federalreservebanks"]


### PR DESCRIPTION
Hi @ppeble , thanks for this awesome library! I've tried to follow the contributing guidelines and am happy to make changes if I've done this incorrectly.

This PR adds Juneteenth, [which is now a federal holiday](https://crsreports.congress.gov/product/pdf/IN/IN11697) to the :federalreservebanks region.

I've based it on [a similar one made for the :us region](https://github.com/holidays/definitions/pull/195).