### PR TITLE
Add Platinum Jubilee bank holiday for 2022

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -74,7 +74,7 @@ months:
     week: -1
     wday: 1
     year_ranges:
-      from: 2023      
+      from: 2023
   6:
   - name: Bank Holiday
     regions: [gb]

--- a/gb.yaml
+++ b/gb.yaml
@@ -76,7 +76,7 @@ months:
     year_ranges:
       from: 2023      
   6:
-    name: Bank Holiday
+  - name: Bank Holiday
     regions: [gb]
     mday: 2
     year_ranges:

--- a/gb.yaml
+++ b/gb.yaml
@@ -67,6 +67,25 @@ months:
     regions: [gb]
     week: -1
     wday: 1
+    year_ranges:
+      until: 2021
+  - name: Bank Holiday
+    regions: [gb]
+    week: -1
+    wday: 1
+    year_ranges:
+      from: 2023      
+  6:
+    name: Bank Holiday
+    regions: [gb]
+    mday: 2
+    year_ranges:
+      limited: 2022
+  - name: Platinum Jubilee
+    regions: [gb]
+    mday: 3
+    year_ranges:
+      limited: [2022]
   7:
   - name: Tynwald Day
     regions: [im, gb_iom]

--- a/gb.yaml
+++ b/gb.yaml
@@ -475,3 +475,13 @@ tests:
       regions: ["je"]
     expect:
       name: "Bank Holiday"
+  - given:
+      date: '2022-06-02'
+      regions: ["gb"]
+    expect:
+      name: "Bank Holiday"
+  - given:
+      date: '2022-06-03'
+      regions: ["gb"]
+    expect:
+      name: "Platinum Jubilee"

--- a/gb.yaml
+++ b/gb.yaml
@@ -80,7 +80,7 @@ months:
     regions: [gb]
     mday: 2
     year_ranges:
-      limited: 2022
+      limited: [2022]
   - name: Platinum Jubilee
     regions: [gb]
     mday: 3

--- a/gb.yaml
+++ b/gb.yaml
@@ -481,7 +481,17 @@ tests:
     expect:
       name: "Bank Holiday"
   - given:
+      date: '2022-05-30'
+      regions: ["gb"]
+    expect:
+      holiday: false
+  - given:
       date: '2022-06-03'
       regions: ["gb"]
     expect:
       name: "Platinum Jubilee"
+  - given:
+      date: '2023-05-29'
+      regions: ["gb"]
+    expect:
+      name: "Bank Holiday"


### PR DESCRIPTION
[Extra Bank Holiday to mark The Queen’s Platinum Jubilee in 2022](https://www.gov.uk/government/news/extra-bank-holiday-to-mark-the-queens-platinum-jubilee-in-2022). In addition, the Spring Bank Holiday has been moved to 2nd June for 2022 only.

See [GOV.UK Bank holidays](https://www.gov.uk/bank-holidays#england-and-wales) for an official reference.