### PR TITLE
Update contribution guideline testing instructions

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -15,6 +15,16 @@ Here are the steps to take once you have a good idea on what you want to change:
 * Fork this repository
 * Edit desired definition YAML file(s). If you are adding a new region be sure to update `index.yaml` as well
 * Run `make validate` to ensure that all updates match our definition format
+* Ensure that the tests in holidays pass:
+```
+git clone git@github.com:holidays/holidays.git
+cd holidays
+bundle install
+make clean-defs
+BRANCH=<YOUR_BRANCH_NAME> USER=<YOUR_GITHUB_USERNAME> make point-to-defs-branch
+bundle exec rake generate:definitions
+bundle exec rake test # Alternatively: bundle exec rake test_region <your_region>
+```
 * Open a PR with your changes
 
 Including documentation with your updates is very much appreciated. A simple Wikipedia entry or government link in the comments alongside your changes would be perfect.


### PR DESCRIPTION
The testing instructions don't talk about how to test the integration between holiday and definitions. This updates the CONTRIBUTING doc to make sure it's easily discoverable by new contributors.