### PR TITLE
juneteenth for federalreserve and federalreservebanks

### DIFF
--- a/federalreserve.yaml
+++ b/federalreserve.yaml
@@ -369,3 +369,21 @@ tests:
       options: ["observed"]
     expect:
       name: "Christmas Day"
+  - given:
+      date: '2021-06-18'
+      regions: ["federalreserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
+  - given:
+      date: '2022-06-20'
+      regions: ["federalreserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
+  - given:
+      date: '2023-06-19'
+      regions: ["federalreserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"

--- a/federalreserve.yaml
+++ b/federalreserve.yaml
@@ -25,6 +25,13 @@ months:
     week: -1
     wday: 1
     regions: [federalreserve]
+  6:
+  - name: Juneteenth National Independence Day
+    regions: [federalreserve]
+    mday: 19
+    observed: to_weekday_if_weekend(date)
+    year_ranges:
+      from: 2021
   7:
   - name: Independence Day
     regions: [federalreserve]

--- a/federalreservebanks.yaml
+++ b/federalreservebanks.yaml
@@ -92,18 +92,6 @@ tests:
     expect:
       name: "Memorial Day"
   - given:
-      date: ['2021-06-19']
-      regions: ["federalreservebanks"]
-      options: ["observed"]
-    expect:
-      holiday: false
-  - given:
-      date: ['2021-06-18']
-      regions: ["federalreservebanks"]
-      options: ["observed"]
-    expect:
-      name: "Juneteenth National Independence Day"
-  - given:
       date: '2012-07-04'
       regions: ["federalreservebanks"]
       options: ["observed"]
@@ -819,3 +807,15 @@ tests:
       options: ["observed"]
     expect:
       name: "Christmas Day"
+  - given:
+      date: '2022-06-20'
+      regions: ["federalreservebanks"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
+  - given:
+      date: '2023-06-19'
+      regions: ["federalreservebanks"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"

--- a/federalreservebanks.yaml
+++ b/federalreservebanks.yaml
@@ -33,7 +33,7 @@ months:
   - name: Juneteenth National Independence Day
     regions: [federalreservebanks]
     mday: 19
-    observed: to_weekday_if_weekend(date)
+    observed: to_monday_if_sunday(date)
     year_ranges:
       from: 2021
   7:


### PR DESCRIPTION
`federalreservebanks` region had a bug for Juneteenth holiday. It was using `to_weekday_if_weekend` instead of `to_monday_if_sunday`.

`federalreserve` region was missing Juneteenth holiday altogether.