### PR TITLE
Add planned 2023 ocurrence of Latvian Song and Dance festival

### DIFF
--- a/lv.yaml
+++ b/lv.yaml
@@ -1,6 +1,6 @@
 # Latvian holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2019-05-01
+# Updated: 2022-02-19
 # Sources:
 # - https://likumi.lv/ta/id/72608 (Likums "Par svētku, atceres un atzīmējamām dienām")
 ---
@@ -84,8 +84,11 @@ methods:
         # https://likumi.lv/ta/id/281541 (Ministru kabineta rīkojums Nr. 252 "Par XXVI Vispārējo latviešu dziesmu un XVI Deju svētku norises laiku")
         Date.new(2018, 7, 8)
       when 2023
+        # https://likumi.lv/ta/id/330067 (Ministru kabineta rīkojums Nr. 92 "Par XXVII Vispārējo latviešu dziesmu un XVII Deju svētku norises laiku")
+        Date.new(2023, 7, 9)
+      when 2028
         # Event's period/next year is known, but precise dates aren't.
-        # Previously, dates were announced 2 years ahead, so at ~2021-05 this method would need to be revisited.
+        # Previously, dates were announced 2 years ahead, so on ~2026-05 this method would need to be revisited.
       end
 
 tests:
@@ -152,18 +155,18 @@ tests:
     expect:
       name: "Jāņu diena"
   - given:
-      date: '2018-07-08'
+      date: ['2018-07-08', '2023-07-09']
       regions: ["lv"]
     expect:
       name: "Vispārējo latviešu Dziesmu un deju svētku noslēguma diena"
   - given:
-      date: '2018-07-09'
+      date: ['2018-07-09', '2023-07-10']
       regions: ["lv"]
       options: ["observed"]
     expect:
       name: "Vispārējo latviešu Dziesmu un deju svētku noslēguma diena"
   - given:
-      date: ['2019-07-08', '2019-07-09']
+      date: ['2019-07-08', '2019-07-09', '2022-07-08', '2022-07-09', '2024-07-08', '2024-07-09']
       regions: ["lv"]
     expect:
       holiday: false


### PR DESCRIPTION
Recently approved by Government of Latvia, to take place in July of 2023.

Hence, adding festival's end date to definition list. 