### PR TITLE
Update holiday september 15 in mexico as informal

### DIFF
--- a/mx.yaml
+++ b/mx.yaml
@@ -123,6 +123,12 @@ tests:
     expect:
       name: "Cinco de Mayo"
   - given:
+      date: '2007-09-15'
+      regions: ["mx"]
+      options: ["informal"]
+    expect:
+      name: "Grito de Dolores"
+  - given:
       date: '2007-09-16'
       regions: ["mx"]
       options: ["informal"]

--- a/mx.yaml
+++ b/mx.yaml
@@ -58,6 +58,7 @@ months:
   - name: Grito de Dolores
     regions: [mx]
     mday: 15
+    type: informal
   - name: Día de la Independencia
     regions: [mx]
     mday: 16


### PR DESCRIPTION
# Update holiday for Mexico
In Mexico the holiday September 15 *Grito de Dolores* is an informal date, however it is marked as formal. You can see the formal dates  in the [government page for mexico](https://www.gob.mx/profedet/es/articulos/sabes-cuales-son-los-dias-de-descanso-obligatorios-163134?idiom=es).

![Screenshot from 2022-03-31 16-20-07](https://user-images.githubusercontent.com/26417452/161151201-21752f6c-851f-434e-b378-d1f41c302b6f.png)
