### PR TITLE
bugfix: Juneteenth Saturday behavior

### DIFF
--- a/federalreservebanks.yaml
+++ b/federalreservebanks.yaml
@@ -33,7 +33,7 @@ months:
   - name: Juneteenth National Independence Day
     regions: [federalreservebanks]
     mday: 19
-    observed: to_weekday_if_weekend(date)
+    observed: to_monday_if_sunday(date)
     year_ranges:
       from: 2021
   7:
@@ -96,9 +96,15 @@ tests:
       regions: ["federalreservebanks"]
       options: ["observed"]
     expect:
-      holiday: false
+      name: "Juneteenth National Independence Day"
   - given:
       date: ['2021-06-18']
+      regions: ["federalreservebanks"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2022-06-20']
       regions: ["federalreservebanks"]
       options: ["observed"]
     expect:


### PR DESCRIPTION
According to the [Federal Reserve website](https://www.federalreserve.gov/aboutthefed/k8.htm), bank holidays that fall on a Saturday are still observed on that Saturday. Bank holidays that fall on a Sunday are observed the following Monday. This updates the rules for Juneteenth's observed date to follow these rules. It also lines up with the rules for all the other federal reserve holidays in this definition.

I've updated tests for this new behavior and added another test to ensure the Sunday case is handled.