### PR TITLE
Add Juneteenth to federalreserve region

### DIFF
--- a/federalreserve.yaml
+++ b/federalreserve.yaml
@@ -25,6 +25,13 @@ months:
     week: -1
     wday: 1
     regions: [federalreserve]
+  6:
+  - name: Juneteenth National Independence Day
+    regions: [federalreservebanks]
+    mday: 19
+    observed: to_weekday_if_weekend(date)
+    year_ranges:
+      from: 2021
   7:
   - name: Independence Day
     regions: [federalreserve]
@@ -80,6 +87,18 @@ tests:
       options: ["observed"]
     expect:
       name: "Memorial Day"
+  - given:
+      date: ['2021-06-19']
+      regions: ["federalreserve"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2021-06-18']
+      regions: ["federalreserve"]
+      options: ["observed"]
+    expect:
+      name: "Juneteenth National Independence Day"
   - given:
       date: '2012-07-04'
       regions: ["federalreserve"]


### PR DESCRIPTION
Hi @ppeble! This PR adds Juneteenth to the :federalreserve region.

I've based it on https://github.com/holidays/definitions/pull/202.