### PR TITLE
[rs] change 9th of May dan pobede to informal holiday

### DIFF
--- a/rs_cyrl.yaml
+++ b/rs_cyrl.yaml
@@ -54,6 +54,7 @@ months:
     mday: 2
   - name: Дан победе над фашизмом # Victory Day
     regions: [rs_cyrl]
+    type: informal
     mday: 9
   6:
   - name: Видовдан # Saint Vitus Day
@@ -93,6 +94,7 @@ tests:
   - given:
       date: '2017-5-9'
       regions: ["rs_cyrl"]
+      options: ["informal"]
     expect:
       name: "Дан победе над фашизмом"
   - given:

--- a/rs_la.yaml
+++ b/rs_la.yaml
@@ -54,6 +54,7 @@ months:
     mday: 2
   - name: Dan pobede # Victory Day
     regions: [rs_la]
+    type: informal
     mday: 9
   6:
   - name: Vidovdan # Saint Vitus Day
@@ -93,6 +94,7 @@ tests:
   - given:
       date: '2017-5-9'
       regions: ["rs_la"]
+      options: ["informal"]
     expect:
       name: "Dan pobede"
   - given:


### PR DESCRIPTION
9th of May (dan pobede) is not a work free day. I didnt find any information on whether or not this should count as a holiday or not (also checked some other countries to see if there are similar occurences but I didnt find any) or what a holiday means in the context of this PR. If i made a mistake please say so.

How i percieved this repository is to allow developers to easily distinguish between working days and non working ones. Since 9th of May is not a work free day I propose to have it marked as an **informal** holiday. 


```
╰─➤  make                                                                                                                                                                                                                                                                                              
bundle exec ruby lib/validation/run.rb
Success!
Definition count: 73
```
