### PR TITLE
Correct KE holidays indentation

### DIFF
--- a/ke.yaml
+++ b/ke.yaml
@@ -85,12 +85,12 @@ tests:
       regions: ["ke"]
     expect:
       name: "Huduma Day"
-   - given:
+  - given:
       date: '2018-10-20'
       regions: ["ke"]
     expect:
       name: "Mashujaa Day"
-   - given:
+  - given:
       date: '2019-12-12'
       regions: ["ke"]
     expect:


### PR DESCRIPTION
This indentation made the holidays file unparsable.