### PR TITLE
adds Intern. Women's Day holiday for Deutschland-Mecklenburg Vorpommern

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -357,7 +357,7 @@ tests:
       holiday: false
   - given:
       date: '2019-03-08'
-      regions: ["de_be"]
+      regions: ["de_be", "de_mv"]
     expect:
       name: "Internationaler Frauentag"
   - given:

--- a/de.yaml
+++ b/de.yaml
@@ -84,11 +84,11 @@ months:
     regions: [de_bw, de_by, de_st]
     mday: 6
   3:
-   - name: Internationaler Frauentag
-     regions: [de_be, de_mv]
-     mday: 8
-     year_ranges:
-       from: 2019
+  - name: Internationaler Frauentag
+    regions: [de_be, de_mv]
+    mday: 8
+    year_ranges:
+      from: 2019
   5:
   - name: Tag der Arbeit
     regions: [de]

--- a/de.yaml
+++ b/de.yaml
@@ -84,11 +84,11 @@ months:
     regions: [de_bw, de_by, de_st]
     mday: 6
   3:
-    - name: Internationaler Frauentag
-      regions: [de_be, de_mv]
-      mday: 8
-      year_ranges:
-        from: 2019
+   - name: Internationaler Frauentag
+     regions: [de_be, de_mv]
+     mday: 8
+     year_ranges:
+       from: 2019
   5:
   - name: Tag der Arbeit
     regions: [de]

--- a/de.yaml
+++ b/de.yaml
@@ -85,10 +85,15 @@ months:
     mday: 6
   3:
   - name: Internationaler Frauentag
-    regions: [de_be, de_mv]
+    regions: [de_be]
     mday: 8
     year_ranges:
       from: 2019
+  - name: Internationaler Frauentag
+    regions: [de_mv]
+    mday: 8
+    year_ranges:
+      from: 2023
   5:
   - name: Tag der Arbeit
     regions: [de]
@@ -357,7 +362,12 @@ tests:
       holiday: false
   - given:
       date: '2019-03-08'
-      regions: ["de_be", "de_mv"]
+      regions: ["de_be"]
+    expect:
+      name: "Internationaler Frauentag"
+  - given:
+      date: '2023-03-08'
+      regions: ["de_mv"]
     expect:
       name: "Internationaler Frauentag"
   - given:

--- a/de.yaml
+++ b/de.yaml
@@ -85,7 +85,7 @@ months:
     mday: 6
   3:
     - name: Internationaler Frauentag
-      regions: [de_be]
+      regions: [de_be, de_mv]
       mday: 8
       year_ranges:
         from: 2019


### PR DESCRIPTION
The `Internationaler Frauentag` in Germany beside Berlin is also a holiday in Mecklenburg-Vorpommern.

[German Wikipedia](https://de.wikipedia.org/wiki/Internationaler_Frauentag#Der_Frauentag_als_gesetzlicher_Feiertag)