### PR TITLE
Adds Coronation Day holiday in the UK

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -65,6 +65,11 @@ months:
     wday: 1
     year_ranges:
       from: 2021
+  - name: Coronation of King Charles III and Queen Camilla
+    regions: [je, gb_jsy, gg, gb_gsy]
+    mday: 8
+    year_ranges:
+      limited: [2023]
   - name: Liberation Day
     regions: [je, gb_jsy, gg, gb_gsy]
     mday: 9


### PR DESCRIPTION
There is an extra holiday on 8 May 2023 for the Coronation of King Charles III and Queen Camilla.

See: https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom / https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii

Hopefully I've done everything necessary, checking the CONTRIBUTING guide: 
- [x] Fork this repository 
- [x] Edit desired definition YAML file(s). If you are adding a new region be sure to update `index.yaml` as well
- [x] Run `make validate` to ensure that all updates match our definition format
- [x] Ensure that the tests in holidays pass:
- [x] Open a PR with your changes

Let me know if you need anything else. Thank you for the gem! 💎 