### PR TITLE
(au_act) retire family day, start reconiciliation day in au_act

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -92,6 +92,11 @@ months:
   - name: May Public Holiday
     regions: [au_sa]
     function: may_pub_hol_sa(year)
+  - name: Reconciliation Day
+    regions: [au_act]
+    function: to_nearest_monday_after(date)
+    year_ranges:
+      from: 2018
   6:
   - name: Western Australia Day
     regions: [au_wa]
@@ -131,6 +136,8 @@ months:
     regions: [au_act]
     week: -1
     wday: 1
+    year_ranges:
+      until: 2017
   10:
   - name: Friday before the AFL Grand Final
     regions: [au_vic]
@@ -283,6 +290,25 @@ methods:
       else
         Date.civil(year, 8, first_friday) + 5
       end
+  to_nearest_monday_after:
+    arguments: date
+    ruby: |
+        case date.wday
+        when 6
+          date += 2
+        when 5
+          date += 3
+        when 4
+          date += 4
+        when 3
+          date += 5
+        when 2
+          date += 6
+        when 0
+          date += 1
+        end
+
+        date
 
 tests:
   - given:
@@ -814,3 +840,13 @@ tests:
       regions: ['au']
     expect:
       holiday: false
+  - given:
+      date: '2024-05-27'
+      regions: ['au_act']
+    expect:
+      name: "Reconciliation Day"
+  - given:
+      date: '2025-06-02'
+      regions: ['au_act']
+    expect:
+      name: "Reconciliation Day"


### PR DESCRIPTION
Retire Family Day in ACT ([source](https://en.wikipedia.org/wiki/Family_Day))
> In 2018, Family and Community Day will no longer be a public holiday in the ACT. Replacing it is [Reconciliation Day](https://en.wikipedia.org/wiki/Reconciliation_Day), held on the first Monday on or after May 27.

Start Reconciliation Day in ACT ([source](https://en.wikipedia.org/wiki/National_Reconciliation_Week#:~:text=Reconciliation%20Day%20is%20a%20public,anniversary%20of%20the%201967%20referendum.))
> Reconciliation Day is a [public holiday](https://en.wikipedia.org/wiki/Public_holiday) in the [Australian Capital Territory](https://en.wikipedia.org/wiki/Australian_Capital_Territory) marking the start of National Reconciliation Week. It is held on the first Monday after or on 27 May, the anniversary of the [1967 referendum](https://en.wikipedia.org/wiki/Australian_referendum,_1967_(Aboriginals)). It was held for the first time on 28 May 2018.