### PR TITLE
Fix Truth and Reconciliation (Canada)- monday if weekend; stat in 4 regions, optional in 3

### DIFF
--- a/ca.yaml
+++ b/ca.yaml
@@ -177,9 +177,16 @@ months:
     week: 1
     regions: [ca]
     wday: 1
-  - name: National Day for Truth and Reconciliation
-    regions: [ca]
+  - name: National Day for Truth and Reconciliation (statutory)
+    regions: [ca_bc, ca_nt, ca_pe, ca_yt]
     mday: 30
+    observed: to_monday_if_weekend(date)
+    year_ranges:
+      from: 2021
+  - name: National Day for Truth and Reconciliation (informal)
+    regions: [ca_ab, ca_mb, ca_nu]
+    mday: 30
+    observed: to_monday_if_weekend(date)
     year_ranges:
       from: 2021
   10:
@@ -772,12 +779,24 @@ tests:
   # National Day for Truth and Reconciliation
   - given:
       date: '2021-09-30'
-      regions: ["ca"]
+      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt"]
+      options: ["observed"]
+    expect:
+      name: "National Day for Truth and Reconciliation"
+  - given:
+      date: '2021-09-30'
+      regions: ["ca_ab", "ca_mb", "ca_nu"]
+      options: ["informal"]
+    expect:
+      name: "National Day for Truth and Reconciliation"
+  - given:
+      date: '2023-10-02'
+      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt", "ca_ab", "ca_mb", "ca_nu"]
     expect:
       name: "National Day for Truth and Reconciliation"
   - given:
       date: '2026-09-30'
-      regions: ["ca"]
+      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt", "ca_ab", "ca_mb", "ca_nu"]
     expect:
       name: "National Day for Truth and Reconciliation"
 

--- a/ca.yaml
+++ b/ca.yaml
@@ -187,6 +187,7 @@ months:
     regions: [ca_ab, ca_mb, ca_nu]
     mday: 30
     observed: to_monday_if_weekend(date)
+    type: informal
     year_ranges:
       from: 2021
   10:

--- a/ca.yaml
+++ b/ca.yaml
@@ -781,7 +781,6 @@ tests:
   - given:
       date: '2021-09-30'
       regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt"]
-      options: ["observed"]
     expect:
       name: "National Day for Truth and Reconciliation"
   - given:
@@ -799,7 +798,7 @@ tests:
   - given:
       date: '2023-10-02'
       regions: ["ca_ab", "ca_mb", "ca_nu"]
-      options: ["informal"]
+      options: ["informal", "observed"]
     expect:
       name: "National Day for Truth and Reconciliation"
   - given:
@@ -811,7 +810,7 @@ tests:
   - given:
       date: '2026-09-30'
       regions: ["ca_ab", "ca_mb", "ca_nu"]
-      options: ["informal"]
+      options: ["informal", "observed"]
     expect:
       name: "National Day for Truth and Reconciliation"
 

--- a/ca.yaml
+++ b/ca.yaml
@@ -791,12 +791,26 @@ tests:
       name: "National Day for Truth and Reconciliation"
   - given:
       date: '2023-10-02'
-      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt", "ca_ab", "ca_mb", "ca_nu"]
+      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt"]
+      options: ["observed"]
+    expect:
+      name: "National Day for Truth and Reconciliation"
+  - given:
+      date: '2023-10-02'
+      regions: ["ca_ab", "ca_mb", "ca_nu"]
+      options: ["informal"]
     expect:
       name: "National Day for Truth and Reconciliation"
   - given:
       date: '2026-09-30'
-      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt", "ca_ab", "ca_mb", "ca_nu"]
+      regions: ["ca_bc", "ca_nt", "ca_pe", "ca_yt"]
+      options: ["observed"]
+    expect:
+      name: "National Day for Truth and Reconciliation"
+  - given:
+      date: '2026-09-30'
+      regions: ["ca_ab", "ca_mb", "ca_nu"]
+      options: ["informal"]
     expect:
       name: "National Day for Truth and Reconciliation"
 

--- a/ca.yaml
+++ b/ca.yaml
@@ -177,13 +177,13 @@ months:
     week: 1
     regions: [ca]
     wday: 1
-  - name: National Day for Truth and Reconciliation (statutory)
+  - name: National Day for Truth and Reconciliation
     regions: [ca_bc, ca_nt, ca_pe, ca_yt]
     mday: 30
     observed: to_monday_if_weekend(date)
     year_ranges:
       from: 2021
-  - name: National Day for Truth and Reconciliation (informal)
+  - name: National Day for Truth and Reconciliation
     regions: [ca_ab, ca_mb, ca_nu]
     mday: 30
     observed: to_monday_if_weekend(date)


### PR DESCRIPTION
Context: We are using the holiday gem to manage holiday calendars and time-off calculations for international employees. It is important to us that the legally required holidays are accurately represented in each region, as well as the observed date.

National Truth and Reconciliation Day in Canada was created as a Federal holiday in 2021, but only for employees of the federal government.

Four regions recognize this as a statutory holiday for all workers: British Columbia, Northwest Territories, Prince Edward Island, and Yukon Territory.

Three regions recognize this as an optional holiday, at the employer's discretion: Alberta, Manitoba, Nunavut

Also, when it falls on a weekend it is observed the following monday.

https://canada-holidays.ca/
- you can drill down into each province/territory to confirm
- the github page has official references including legislation for each region

Question: Do we care to include holidays that only apply to employees of the federal government in the holiday definitions? Perhaps the "informal" version of the holiday should be expanded to cover all of the rest of Canada, instead of just the regions that officially recognize it as an optional holiday for all workers?

PS: There is a test in `test/integration/test_holidays.rb` that fails now because the number of holidays returned is one less. Should I make a PR for that change in the main repo as well? Happy to do so, but here's the diff:
```
diff --git a/test/integration/test_holidays.rb b/test/integration/test_holidays.rb
index 72ffa04..c665e8f 100644
--- a/test/integration/test_holidays.rb
+++ b/test/integration/test_holidays.rb
@@ -155,7 +155,7 @@ class HolidaysTests < Test::Unit::TestCase
     assert_equal 11, holidays.length

     holidays = Holidays.year_holidays([:ca_on], Date.civil(2050, 1, 1))
-    assert_equal 10, holidays.length
+    assert_equal 9, holidays.length

     holidays = Holidays.year_holidays([:jp], Date.civil(2070, 1, 1))
     assert_equal 19, holidays.length
(END)
```