### PR TITLE
Update NZ Queen's Birthday to King's Birthday

### DIFF
--- a/nz.yaml
+++ b/nz.yaml
@@ -70,6 +70,14 @@ months:
     regions: [nz]
     week: 1
     wday: 1
+    year_ranges:
+      until: 2022
+  - name: King's Birthday
+    regions: [nz]
+    week: 1
+    wday: 1
+    year_ranges:
+      from: 2023
   9:
   - name: Dominion Day
     regions: [nz_sc]
@@ -264,6 +272,16 @@ tests:
       regions: ["nz"]
     expect:
       name: "Matariki"
+  - given:
+      date: "2022-06-06"
+      regions: ["nz"]
+    expect:
+      name: "Queen's Birthday"
+  - given:
+      date: "2023-06-05"
+      regions: ["nz"]
+    expect:
+      name: "King's Birthday"
 
 
 methods:


### PR DESCRIPTION
👋 This PR includes updating a NZ holiday to reflect the monarch change in 2022.

Documentation for Queen's Birthday naming - https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/

Documentation for current King's Birthday naming - https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/