### PR TITLE
[br] Adds black consciousness holiday

### DIFF
--- a/br.yaml
+++ b/br.yaml
@@ -51,6 +51,11 @@ months:
   - name: Proclamação da República
     regions: [br]
     mday: 15
+  - name: Dia Nacional de Zumbi e da Consciência Negra
+    regions: [br]
+    mday: 20
+    year_ranges:
+      from: 2024
   12:
   - name: Natal
     regions: [br]
@@ -153,6 +158,18 @@ tests:
       options: ["informal"]
     expect:
       name: "Proclamação da República"
+  - given:
+      date: '2023-11-20'
+      regions: ["br"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: '2024-11-20'
+      regions: ["br"]
+      options: ["informal"]
+    expect:
+      name: "Dia Nacional de Zumbi e da Consciência Negra"
   - given:
       date: '2008-12-25'
       regions: ["br"]

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-In this repository we have all of the definitions that are used in holiday calcuations. We rely on users around the world to help keep our definitions accurate and up to date.
+In this repository we have all of the definitions that are used in holiday calculations. We rely on users around the world to help keep our definitions accurate and up to date.
 
 ## Code of Conduct
 


### PR DESCRIPTION
The 20th of November is now officially the "Dia Nacional de Zumbi e da Consciência Negra" (Black Consciousness) national holiday in Brazil.

Source:
"Diário Oficial da União" (Brazil's Federal Register) - https://www.in.gov.br/en/web/dou/-/lei-n-14.759-de-21-de-dezembro-de-2023-532716296