### PR TITLE
Update: Added South Australia to easter Sunday holiday list

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -20,7 +20,7 @@ months:
     regions: [au_nsw, au_vic]
     function: easter(year)
   - name: Easter Sunday
-    regions: [au_qld, au_act]
+    regions: [au_qld, au_act, au_sa]
     function: easter(year)
     year_ranges:
       from: 2017
@@ -788,6 +788,11 @@ tests:
   - given:
       date: '2017-04-16'
       regions: ["au_qld"]
+    expect:
+      name: "Easter Sunday"
+  - given:
+      date: '2024-03-31'
+      regions: ['au_sa']
     expect:
       name: "Easter Sunday"
   - given:


### PR DESCRIPTION
**Ticket:** https://tandadocs.atlassian.net/browse/L2S-3570

 - Added South Australia to the list of countries that have the sunday public holiday for easter
 - The holiday has been set to exist from 2024 onwards, tests were added to ensure that it's working for this year and not last year