### PR TITLE
use correct country code gr for Greece

### DIFF
--- a/gr.yml
+++ b/gr.yml
@@ -12,147 +12,147 @@
 months:
   0:
   - name: Μεγάλη Παρασκευή
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
     function_modifier: -2
   - name: Μεγάλο Σάββατο
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
     function_modifier: -1
   - name: Κυριακή του Πάσχα
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
   - name: Δευτέρα του Πάσχα
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
     function_modifier: 1
   - name: Καθαρά Δευτέρα
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
     function_modifier: -48
   - name: Αγίου Πνεύματος
-    regions: [el]
+    regions: [gr]
     function: orthodox_easter(year)
     function_modifier: 50
   1:
   - name: Πρωτοχρονιά
-    regions: [el]
+    regions: [gr]
     mday: 1
   - name: Θεοφάνεια
-    regions: [el]
+    regions: [gr]
     mday: 6
   3:
   - name: Επέτειος της Επανάστασης του 1821
-    regions: [el]
+    regions: [gr]
     mday: 25
   5:
   - name: Πρωτομαγιά
-    regions: [el]
+    regions: [gr]
     mday: 1
   8:
   - name: Κοίμηση της Θεοτόκου
-    regions: [el]
+    regions: [gr]
     mday: 15
   10:
   - name: Επέτειος του Όχι
-    regions: [el]
+    regions: [gr]
     mday: 28
   12:
   - name: Χριστούγεννα
-    regions: [el]
+    regions: [gr]
     mday: 25
   - name: Δεύτερη ημέρα των Χριστουγέννων
-    regions: [el]
+    regions: [gr]
     mday: 26
 
 tests:
   - given:
       date: '2011-01-01'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Πρωτοχρονιά"
   - given:
       date: '2011-01-06'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Θεοφάνεια"
   - given:
       date: '2011-04-22'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Μεγάλη Παρασκευή"
   - given:
       date: '1970-04-25'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Μεγάλο Σάββατο"
   - given:
       date: '1985-04-14'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Κυριακή του Πάσχα"
   - given:
       date: '2011-04-24'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Κυριακή του Πάσχα"
   - given:
       date: '2027-05-02'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Κυριακή του Πάσχα"
   - given:
       date: '2046-04-30'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Δευτέρα του Πάσχα"
   - given:
       date: '2011-05-01'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Πρωτομαγιά"
   - given:
       date: '2011-06-13'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Αγίου Πνεύματος"
   - given:
       date: '2012-06-04'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Αγίου Πνεύματος"
   - given:
       date: '2011-03-07'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Καθαρά Δευτέρα"
   - given:
       date: '2012-02-27'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Καθαρά Δευτέρα"
   - given:
       date: '2011-12-25'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Χριστούγεννα"
   - given:
       date: '2011-12-26'
-      regions: ["el"]
+      regions: ["gr"]
       options: ["informal"]
     expect:
       name: "Δεύτερη ημέρα των Χριστουγέννων"


### PR DESCRIPTION
`el` is the ISO 639 code for Greek language, but `gr` is the ISO 3166 code for Greece