### PR TITLE
Update Australian Queen/King public holiday

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -107,6 +107,14 @@ months:
     regions: [au_act, au_nsw, au_sa, au_tas, au_nt, au_vic]
     week: 2
     wday: 1
+    year_ranges:
+      until: 2022
+  - name: King's Birthday
+    regions: [au_act, au_nsw, au_sa, au_tas, au_nt, au_vic]
+    week: 2
+    wday: 1
+    year_ranges:
+      from: 2023
   - name: Queen's Birthday
     regions: [au_qld]
     function: qld_queens_birthday_june(year)
@@ -133,6 +141,14 @@ months:
     regions: [au_wa]
     week: -1
     wday: 1
+    year_ranges:
+      until: 2021
+  - name: King's Birthday
+    regions: [au_wa]
+    week: -1
+    wday: 1
+    year_ranges:
+      from: 2022
   - name: "Family & Community Day"
     regions: [au_act]
     week: -1
@@ -155,6 +171,14 @@ months:
     regions: [au_qld]
     function: qld_queens_bday_october(year)
     observed: to_monday_if_weekend(date)
+    year_ranges:
+      until: 2022
+  - name: King's Birthday
+    regions: [au_qld]
+    function: qld_kings_bday_october(year)
+    observed: to_monday_if_weekend(date)
+    year_ranges:
+      from: 2023
   - name: Royal Hobart Show
     regions: [au_tas_south]
     function: hobart_show_day(year)
@@ -218,6 +242,17 @@ methods:
         Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
       elsif year == 2012
         1
+      else
+        nil
+      end
+  qld_kings_bday_october:
+    # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
+    # celebrated twice in 2012
+    # in october again from 2016
+    arguments: year
+    ruby: |
+      if year >= 2023
+        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
       else
         nil
       end
@@ -347,15 +382,35 @@ tests:
     expect:
       name: 'Labour Day'
   - given:
-      date: ['2012-06-11', '2012-10-01', '2013-6-10', '2015-6-8', '2016-10-3']
+      date: ['2012-06-11', '2012-10-01', '2013-6-10', '2015-6-8', '2016-10-3', '2022-10-03']
       regions: ["au_qld"]
     expect:
       name: "Queen's Birthday"
   - given:
-      date: ['2014-09-29', '2015-09-28', '2016-09-26']
+      date: ['2023-10-2']
+      regions: ["au_qld"]
+    expect:
+      name: "King's Birthday"
+  - given:
+      date: ['2022-06-13']
+      regions: ["au_act", "au_nsw", "au_sa", "au_tas", "au_nt", "au_vic"]
+    expect:
+      name: "Queen's Birthday"
+  - given:
+      date: ['2023-06-12']
+      regions: ["au_act", "au_nsw", "au_sa", "au_tas", "au_nt", "au_vic"]
+    expect:
+      name: "King's Birthday"
+  - given:
+      date: ['2014-09-29', '2015-09-28', '2016-09-26', '2021-09-27']
       regions: ["au_wa"]
     expect:
       name: "Queen's Birthday"
+  - given:
+      date: ['2022-09-26', '2023-09-25']
+      regions: ["au_wa"]
+    expect:
+      name: "King's Birthday"
   - given:
       date: '2014-09-29'
       regions: ["au_act"]


### PR DESCRIPTION
Updating the name of the holidays from Queen to King.

In the WA region, the holiday has already been renamed to King in 2022, in other regions only in 2023.

Useful links:
https://publicholidays.com.au/kings-birthday/
![image](https://github.com/holidays/definitions/assets/8649731/27c98edf-2583-47c6-b940-dd5142ca48a1)
https://www.commerce.wa.gov.au/labour-relations/previous-years-public-holiday-dates
![image](https://github.com/holidays/definitions/assets/8649731/20b5da5b-1f37-4707-a2b5-26ff92131a49)
