### PR TITLE
Remove September 1st from Slovak holidays

### DIFF
--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -40,7 +40,7 @@ Non-standard regions (e.g. `ecbtarget`, `federalreserve`, etc) must be all one w
 
 We consider `formal` dates as government-defined holidays, what are commonly called **statutory** holidays. These could be the kinds of holidays where everyone stays home from work or perhaps are bank holidays but it is *not required* for a holiday to have these features to be considered formal.
 
-`Informal` holidays are holidays that everyone knows about but aren't enshrined in law. For example, Valentine's Day in the US is considered an informal holiday.
+`Informal` holidays are holidays that are not days off work. Usually that means a holiday everyone knows about but that isn't enshrined in law, such as Valentine's Day in the US. It also covers the reverse case, a holiday that remains in law but is an ordinary working day, such as Slovakia's `Deň Ústavy Slovenskej republiky`, a state holiday that stopped being a day of rest in 2024. Either way it stays out of the default results and is returned only when `:informal` is asked for. If a holiday changes status partway through its life, use `year_ranges` to split the definition at the year it changed.
 
 We recognize that these definitions can be highly subjective. If you disagree with the current status of a holiday please open an issue so we can discuss it.
 

--- a/sk.yaml
+++ b/sk.yaml
@@ -1,6 +1,6 @@
 # Slovak holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2013-12-26.
+# Updated: 2024-09-04.
 # Sources:
 # - http://sk.wikipedia.org/wiki/Slovensk%C3%A9_%C5%A1t%C3%A1tne_sviatky
 ---
@@ -40,6 +40,10 @@ months:
   - name: Deň Ústavy Slovenskej republiky
     regions: [sk]
     mday: 1
+    year_ranges:
+      between:
+        start: 1994
+        end: 2023
   - name: Sedembolestná Panna Mária
     regions: [sk]
     mday: 15
@@ -116,6 +120,12 @@ tests:
       options: ["informal"]
     expect:
       name: "Deň Ústavy Slovenskej republiky"
+  - given:
+      date: ['2024-09-01', '1993-09-01']
+      regions: ["sk"]
+      options: ["informal"]
+    expect:
+      holiday: false
   - given:
       date: '2013-09-15'
       regions: ["sk"]

--- a/sk.yaml
+++ b/sk.yaml
@@ -1,8 +1,9 @@
 # Slovak holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2025-12-03.
+# Updated: 2026-07-22.
 # Sources:
 # - https://www.vlada.gov.sk/slovensko/statne-sviatky/
+# - https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241/
 ---
 region_names:
   sk: "Slovakia"
@@ -39,6 +40,19 @@ months:
     regions: [sk]
     mday: 29
   9:
+  # A state holiday throughout, but a working day from 2024 onwards
+  # under zákon č. 530/2023 Z. z.
+  - name: Deň Ústavy Slovenskej republiky
+    regions: [sk]
+    mday: 1
+    year_ranges:
+      until: 2023
+  - name: Deň Ústavy Slovenskej republiky
+    regions: [sk]
+    mday: 1
+    type: informal
+    year_ranges:
+      from: 2024
   - name: Sedembolestná Panna Mária
     regions: [sk]
     mday: 15
@@ -46,6 +60,18 @@ months:
   - name: Sviatok všetkých svätých
     regions: [sk]
     mday: 1
+  # A state holiday throughout, but a working day from 2025 onwards.
+  - name: Deň boja za slobodu a demokraciu
+    regions: [sk]
+    mday: 17
+    year_ranges:
+      until: 2024
+  - name: Deň boja za slobodu a demokraciu
+    regions: [sk]
+    mday: 17
+    type: informal
+    year_ranges:
+      from: 2025
   12:
   - name: Štedrý deň
     regions: [sk]
@@ -107,6 +133,22 @@ tests:
     expect:
       name: "Výročie Slovenského národného povstania"
   - given:
+      date: '2023-09-01'
+      regions: ["sk"]
+    expect:
+      name: "Deň Ústavy Slovenskej republiky"
+  - given:
+      date: ['2024-09-01', '2025-09-01']
+      regions: ["sk"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2024-09-01', '2025-09-01']
+      regions: ["sk"]
+      options: ["informal"]
+    expect:
+      name: "Deň Ústavy Slovenskej republiky"
+  - given:
       date: '2025-09-15'
       regions: ["sk"]
       options: ["informal"]
@@ -118,6 +160,22 @@ tests:
       options: ["informal"]
     expect:
       name: "Sviatok všetkých svätých"
+  - given:
+      date: '2024-11-17'
+      regions: ["sk"]
+    expect:
+      name: "Deň boja za slobodu a demokraciu"
+  - given:
+      date: ['2025-11-17', '2026-11-17']
+      regions: ["sk"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2025-11-17', '2026-11-17']
+      regions: ["sk"]
+      options: ["informal"]
+    expect:
+      name: "Deň boja za slobodu a demokraciu"
   - given:
       date: '2025-12-24'
       regions: ["sk"]


### PR DESCRIPTION
Hi, a new law was adopted in Slovakia removing the September 1st from public holidays. This law is valid from 2024 https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241/ 

The wikipedia source mentioned in sk.yaml is already updated with this change.
<img width="572" alt="image" src="https://github.com/user-attachments/assets/1cdf0f9e-6876-44ae-b2ff-207ab43c2b9b">
<img width="534" alt="image" src="https://github.com/user-attachments/assets/22e8fbec-87bc-43a3-a7d6-3d345542fb12">
