### PR TITLE
add Juneteenth for UT

### DIFF
--- a/lib/validation/custom_method_validator.rb
+++ b/lib/validation/custom_method_validator.rb
@@ -3,7 +3,7 @@ require_relative 'error'
 module Definitions
   module Validation
     class CustomMethod
-      VALID_ARGUMENTS = ["date", "year", "month", "day"]
+      VALID_ARGUMENTS = ["date", "year", "month", "day", "region"]
 
       def call(methods)
         methods.each do |name, method|

--- a/us.yaml
+++ b/us.yaml
@@ -196,7 +196,7 @@ months:
   - name: Juneteenth National Independence Day
     regions: [us]
     mday: 19
-    observed: juneteenth_national_independence_day(date, region)
+    observed: juneteenth_national_independence_day(region, date)
     year_ranges:
       from: 2021
   - name: Emancipation Day in Texas # fixed
@@ -365,9 +365,9 @@ methods:
     # When Saturday or Sunday, it's on next Monday
     # When Tuesday through Friday, it's on the preceeding Monday
     # all other states it's observed like "to_weekday_if_weekend"
-    arguments: date, region
+    arguments: region, date
     ruby: |
-      if region == "us_ut"
+      if region == :us_ut
         case date.wday
         when 1
           date

--- a/us.yaml
+++ b/us.yaml
@@ -729,16 +729,10 @@ tests:
     expect:
       name: "Emancipation Day in Texas"  
   - given:
-      date: ['2024-06-17', '2027-06-21', '2033-06-20']
+      date: ['2024-06-17', '2027-06-21', '2028-06-19', '2033-06-20']
       regions: ["us_ut"]
     expect:
       name: "Juneteenth National Freedom Day"
-  - given:
-      date: ['2028-06-19']
-      regions: ["us_ut"]
-    expect:
-      name: ["Juneteenth National Freedom Day", "Juneteenth National Independence Day"]
-
 
   - given:
       date: ['2017-6-20', '2020-6-19', '2021-6-21']

--- a/us.yaml
+++ b/us.yaml
@@ -199,6 +199,11 @@ months:
     observed: to_weekday_if_weekend(date)
     year_ranges:
       from: 2021
+  - name: Juneteenth National Freedom Day
+    regions: [us_ut]
+    function: juneteenth_national_freedom_day(year)
+    year_ranges:
+      from: 2022
   - name: Emancipation Day in Texas # fixed
     regions: [us_tx]
     mday: 19
@@ -360,6 +365,22 @@ methods:
       beginning_of_month = Date.civil(year, month, 1)
       king_day = Date.civil(year, month, day_of_holiday)
       king_day.downto(beginning_of_month).find {|date| date if date.wday == 5 }
+  juneteenth_national_freedom_day:
+    # If Saturday or Sunday, it's on next Monday
+    # If it's Tuesday through Friday, it's on the preceeding Monday
+    arguments: year
+    ruby: |
+      date = Date.civil(year, 6, 19)
+      case date.wday
+      when 1
+        date
+      when 2,3,4,5
+        date - (date.wday - 1)
+      when 6
+        date + 2
+      when 0
+        date + 1
+      end
   election_day:
     # Tuesday after the first Monday of November
     arguments: year
@@ -706,7 +727,13 @@ tests:
       date: ['2017-6-19']
       regions: ["us_tx"]
     expect:
-      name: "Emancipation Day in Texas"
+      name: "Emancipation Day in Texas"  
+  - given:
+      date: ['2024-06-17', '2027-06-21', '2028-06-19', '2033-06-20']
+      regions: ["us_ut"]
+    expect:
+      name: "Juneteenth National Freedom Day"
+
 
   - given:
       date: ['2017-6-20', '2020-6-19', '2021-6-21']

--- a/us.yaml
+++ b/us.yaml
@@ -368,6 +368,7 @@ methods:
     arguments: date, region
     ruby: |
       if region == "us_ut"
+        raise "it's utah, baby!"
         case date.wday
         when 1
           date

--- a/us.yaml
+++ b/us.yaml
@@ -368,7 +368,6 @@ methods:
     arguments: date, region
     ruby: |
       if region == "us_ut"
-        raise "it's utah, baby!"
         case date.wday
         when 1
           date

--- a/us.yaml
+++ b/us.yaml
@@ -729,10 +729,15 @@ tests:
     expect:
       name: "Emancipation Day in Texas"  
   - given:
-      date: ['2024-06-17', '2027-06-21', '2028-06-19', '2033-06-20']
+      date: ['2024-06-17', '2027-06-21', '2033-06-20']
       regions: ["us_ut"]
     expect:
       name: "Juneteenth National Freedom Day"
+  - given:
+      date: ['2028-06-19']
+      regions: ["us_ut"]
+    expect:
+      name: ["Juneteenth National Freedom Day", "Juneteenth National Independence Day"]
 
 
   - given:

--- a/us.yaml
+++ b/us.yaml
@@ -367,7 +367,7 @@ methods:
     # all other states it's observed like "to_weekday_if_weekend"
     arguments: date, region
     ruby: |
-      if region == 'us_ut'
+      if region == "us_ut"
         case date.wday
         when 1
           date
@@ -385,7 +385,6 @@ methods:
       else
         date
       end
-
   election_day:
     # Tuesday after the first Monday of November
     arguments: year

--- a/us.yaml
+++ b/us.yaml
@@ -196,14 +196,9 @@ months:
   - name: Juneteenth National Independence Day
     regions: [us]
     mday: 19
-    observed: to_weekday_if_weekend(date)
+    observed: juneteenth_national_independence_day(date, region)
     year_ranges:
       from: 2021
-  - name: Juneteenth National Freedom Day
-    regions: [us_ut]
-    function: juneteenth_national_freedom_day(year)
-    year_ranges:
-      from: 2022
   - name: Emancipation Day in Texas # fixed
     regions: [us_tx]
     mday: 19
@@ -365,22 +360,32 @@ methods:
       beginning_of_month = Date.civil(year, month, 1)
       king_day = Date.civil(year, month, day_of_holiday)
       king_day.downto(beginning_of_month).find {|date| date if date.wday == 5 }
-  juneteenth_national_freedom_day:
-    # If Saturday or Sunday, it's on next Monday
-    # If it's Tuesday through Friday, it's on the preceeding Monday
-    arguments: year
+  juneteenth_national_independence_day:
+    # In Utah...
+    # When Saturday or Sunday, it's on next Monday
+    # When Tuesday through Friday, it's on the preceeding Monday
+    # all other states it's observed like "to_weekday_if_weekend"
+    arguments: date, region
     ruby: |
-      date = Date.civil(year, 6, 19)
-      case date.wday
-      when 1
-        date
-      when 2,3,4,5
-        date - (date.wday - 1)
-      when 6
-        date + 2
-      when 0
+      if region == 'us_ut'
+        case date.wday
+        when 1
+          date
+        when 2,3,4,5
+          date - (date.wday - 1)
+        when 6
+          date + 2
+        when 0
+          date + 1
+        end
+      elsif date.wday == 0
         date + 1
+      elsif date.wday == 6
+        date - 1
+      else
+        date
       end
+
   election_day:
     # Tuesday after the first Monday of November
     arguments: year
@@ -731,8 +736,9 @@ tests:
   - given:
       date: ['2024-06-17', '2027-06-21', '2028-06-19', '2033-06-20']
       regions: ["us_ut"]
+      options: ["observed"]
     expect:
-      name: "Juneteenth National Freedom Day"
+      name: "Juneteenth National Independence Day"
 
   - given:
       date: ['2017-6-20', '2020-6-19', '2021-6-21']


### PR DESCRIPTION
> (i) The Juneteenth National Freedom Day holiday is on June 19, if that day is on a Monday.
(ii) If June 19 is on a Tuesday, Wednesday, Thursday, or Friday, the Juneteenth National
Freedom Day holiday is on the immediately preceding Monday.
(iii) If June 19 is on a Saturday or Sunday, the Juneteenth National Freedom Day holiday is on
the immediately following Monday.

https://le.utah.gov/xcode/Title63G/Chapter1/C63G-1-P3_1800010118000101.pdf