### PR TITLE
Add 2028 one-time Berlin holiday

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -128,6 +128,11 @@ months:
       between:
         start: 1954
         end: 1990
+  - name: Jahrestag des Volksaufstands in der DDR
+    regions: [de_be]
+    mday: 17
+    year_ranges:
+      limited: [2028]
   8:
   - name: Mariä Himmelfahrt
     regions: [de_by_cath, de_by_augsburg, de_sl]
@@ -424,6 +429,11 @@ tests:
       regions: ["de_be"]
     expect:
       name: "Tag der Befreiung"
+  - given:
+      date: '2028-06-17'
+      regions: ["de_be"]
+    expect:
+      name: "Jahrestag des Volksaufstands in der DDR"
   - given:
       date: "2024-09-20"
       regions: ["de_th"]


### PR DESCRIPTION
This PR adds the 2028 one-time holiday on 17.06.28

See [official source](https://www.berlin.de/sen/bjf/service/kalender/ferien/termine/#headline_1_49): "Im Schuljahr 2027/2028 ist der 17. Juni 2028 ein einmaliger gesetzlicher Feiertag." 

[English source](https://www.berlin.de/en/news/9188766-5559700-oneoff-public-holiday-on-8-may-2025.en.html): "In 2028, Berliners will have another one-off public holiday: 17 June. The occasion is the 75th anniversary of the East German uprising. During the uprising of 17 June 1953 [...]"