### PR TITLE
Use Gregorian calendar for Bulgaria

### DIFF
--- a/bg.yaml
+++ b/bg.yaml
@@ -7,33 +7,33 @@ months:
   0:
   - name: Good Friday
     regions: [bg_en]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: -2
   - name: Разпети петък
     regions: [bg_bg]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: -2
   - name: Holy Saturday
     regions: [bg_en]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: -1
   - name: Велика събота
     regions: [bg_bg]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: -1
   - name: Easter Sunday
     regions: [bg_en]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
   - name: Възкресение Христово. Великден
     regions: [bg_bg]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
   - name: Easter Monday
     regions: [bg_en]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: 1
   - name: Възкресение Христово. Великден
     regions: [bg_bg]
-    function: orthodox_easter_julian(year)
+    function: orthodox_easter(year)
     function_modifier: 1
   1:
   - name: New Year's Day
@@ -120,22 +120,22 @@ tests:
     expect:
       name: 'Liberation Day'
   - given:
-      date: '2015-03-28'
+      date: '2015-04-10'
       regions: ["bg_en"]
     expect:
       name: 'Good Friday'
   - given:
-      date: '2015-03-29'
+      date: '2015-04-11'
       regions: ["bg_en"]
     expect:
       name: 'Holy Saturday'
   - given:
-      date: '2015-03-30'
+      date: '2015-04-12'
       regions: ["bg_en"]
     expect:
       name: 'Easter Sunday'
   - given:
-      date: '2015-03-31'
+      date: '2015-04-13'
       regions: ["bg_en"]
     expect:
       name: 'Easter Monday'


### PR DESCRIPTION
Switch to usage of the Gregorian calendar for Bulgaria instead of the Julian one as it led wrong dates for Easter-related holidays.