### PR TITLE
Add updates for us_hi to Juneteenth and Independence Day.

### DIFF
--- a/us.yaml
+++ b/us.yaml
@@ -204,6 +204,13 @@ months:
     observed: to_weekday_if_weekend(date)
     year_ranges:
       from: 2021
+  - name: Juneteenth National Independence Day # Juneteenth is not a formal holiday in all US states, https://en.wikipedia.org/wiki/Juneteenth
+    regions: [us_hi]
+    mday: 19
+    observed: to_weekday_if_weekend(date)
+    type: informal
+    year_ranges:
+      from: 2021
   - name: Emancipation Day in Texas # fixed
     regions: [us_tx]
     mday: 19
@@ -219,7 +226,7 @@ months:
     regions: [us]
     mday: 4
   - name: Independence Day (Holiday)
-    regions: [us_va]
+    regions: [us_va, us_hi]
     mday: 4
     function: to_weekday_if_weekend(date) # Note: Always if Independence Day don't match
   - name: Pioneer Day # fixed
@@ -716,16 +723,22 @@ tests:
     expect:
       name: "King Kamehameha I Day"
   - given:
-      date: ['2021-06-19']
+      date: ['2021-06-18', '2022-06-20', '2023-06-19']
       regions: ["us"]
       options: ["observed"]
     expect:
-      holiday: false
+      name: "Juneteenth National Independence Day"
   - given:
-      date: ['2021-06-18']
-      regions: ["us"]
+      date: ['2021-06-18', '2022-06-20', '2023-06-19']
+      regions: ["us_hi"]
       options: ["observed"]
     expect:
+      name: false
+  - given:
+      date: ['2021-06-18', '2022-06-20', '2023-06-19']
+      regions: ["us_hi"]
+      options: ["informal"]
+    expect: 
       name: "Juneteenth National Independence Day"
   - given:
       date: ['2017-6-19']
@@ -769,7 +782,7 @@ tests:
       holiday: false
   - given:
       date: ['2020-7-3', '2021-7-5', '2026-7-3']
-      regions: ["us_va"]
+      regions: ["us_va, us_hi"]
     expect:
       name: "Independence Day (Holiday)"
   - given:


### PR DESCRIPTION
This creates the following additions:

- Creates new informal holiday for Juneteenth for us_hi (other states may need to be added, as Juneetenth is not observed in all US states as a formal holiday)
- Adds a to weekday if weekend date for Independence Day for us_hi

I believe I wrote the tests correctly, but appreciate double-checking and guidance!