### PR TITLE
Fix FR definitions : Pentecote Sunday is not a official public holiday in france, only the Monday

### DIFF
--- a/fr.yaml
+++ b/fr.yaml
@@ -32,11 +32,11 @@ months:
     regions: [fr]
     function: easter(year)
     function_modifier: 49
+    type: informal
   - name: Lundi de Pentecôte
     regions: [fr]
     function: easter(year)
     function_modifier: 50
-    type: informal
   1:
   - name: Jour de l'an
     regions: [fr]


### PR DESCRIPTION
The change made in this commit https://github.com/holidays/definitions/commit/f07de65de65e1d92e3b3ad0f4b052d664faae314 is wrong and should have not been accepted : 
- the commit talks about Ascension but change the Pentecost definition
- the commit has changed the Pentecost monday to 'informal', while it's an official public holiday, not an informal one. It's the Pentecost *sunday* which is an informal holiday.  

So the definition was correct before that change and this PR revert the change.

You can see the official French definition of public holidays in the French law here : 
  https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006072050/LEGISCTA000006178007/
There are 11 official public holidays (and 2 more in region Alsace-Moselle which are not mentionned in this article)

You can find also find the official list for 2026 here on the French public administration website : https://www.service-public.gouv.fr/particuliers/actualites/A18558

The current definition error prevent us from updating the gem version, we are stuck on version 8.4.1 because of that.

 