### PR TITLE
Replace nil-returning year-gate functions with year_ranges

### DIFF
--- a/au.yaml
+++ b/au.yaml
@@ -62,6 +62,8 @@ months:
   - name: March Public Holiday
     regions: [au_sa]
     function: march_pub_hol_sa(year)
+    year_ranges:
+      from: 2006
   - name: Canberra Day
     regions: [au_act]
     week: 2
@@ -85,6 +87,13 @@ months:
   - name: Labour Day
     regions: [au_qld]
     function: qld_labour_day_may(year)
+    year_ranges:
+      until: 2012
+  - name: Labour Day
+    regions: [au_qld]
+    function: qld_labour_day_may(year)
+    year_ranges:
+      from: 2016
   - name: May Day
     regions: [au_nt]
     week: 1
@@ -92,6 +101,8 @@ months:
   - name: May Public Holiday
     regions: [au_sa]
     function: may_pub_hol_sa(year)
+    year_ranges:
+      until: 2005
   - name: Reconciliation Day
     mday: 27
     regions: [au_act]
@@ -118,6 +129,8 @@ months:
   - name: Queen's Birthday
     regions: [au_qld]
     function: qld_queens_birthday_june(year)
+    year_ranges:
+      until: 2015
   - name: Queensland Day
     regions: [au_qld]
     mday: 6
@@ -167,12 +180,24 @@ months:
     regions: [au_qld]
     function: qld_labour_day_october(year)
     observed: to_monday_if_weekend(date)
+    year_ranges:
+      between:
+        start: 2013
+        end: 2015
+  - name: Queen's Birthday
+    regions: [au_qld]
+    mday: 1
+    observed: to_monday_if_weekend(date)
+    year_ranges:
+      limited: [2012]
   - name: Queen's Birthday
     regions: [au_qld]
     function: qld_queens_bday_october(year)
     observed: to_monday_if_weekend(date)
     year_ranges:
-      until: 2022
+      between:
+        start: 2016
+        end: 2022
   - name: King's Birthday
     regions: [au_qld]
     function: qld_kings_bday_october(year)
@@ -185,7 +210,9 @@ months:
   11:
   - name: G20 Day
     regions: [au_qld_brisbane]
-    function: g20_day_2014_only(year)
+    mday: 14
+    year_ranges:
+      limited: [2014]
   - name: Recreation Day # http://www.timeanddate.com/holidays/australia/recreation-day
     regions: [au_tas_north]
     wday: 1
@@ -239,58 +266,30 @@ methods:
       end
   qld_queens_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # celebrated twice in 2012
-    # in october again from 2016
+    # in october from 2016 (2012 case handled by mday: 1 in the definition)
     arguments: year
     ruby: |
-      if year >= 2016
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-      elsif year == 2012
-        1
-      else
-        nil
-      end
+      Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
   qld_kings_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # celebrated twice in 2012
-    # in october again from 2016
     arguments: year
     ruby: |
-      if year >= 2023
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-      else
-        nil
-      end
+      Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
   qld_queens_birthday_june:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # in june until 2015
     arguments: year
     ruby: |
-      if year <= 2015
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, 1)
-      end
+      Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, 1)
   qld_labour_day_may:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # for 2013 to 2016 it was in October, otherwise it's in May
     arguments: year
     ruby: |
-      if year < 2013 || year >= 2016
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, 1, 1)
-      end
+      Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, 1, 1)
   qld_labour_day_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # for 2013 to 2016 it was in October, otherwise it's in May
     arguments: year
     ruby: |
-      if year >= 2013 && year < 2016
-        Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-      end
-  g20_day_2014_only:
-    # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
-    # G20 day in brisbane, in 2014, on november 14
-    arguments: year
-    ruby: |
-      year == 2014 ? 14 : nil
+      Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
   hobart_show_day:
     # http://worksafe.tas.gov.au/__data/assets/pdf_file/0008/287036/Public_Holidays_2014.pdf
     # The Thursday before the fourth Saturday in October.
@@ -303,21 +302,13 @@ methods:
     # The Holidays Act 1910 provides for the third Monday in May to be a public holiday. Since 2006 this public holiday has been observed on the second Monday in March through the issuing of a special Proclamation by the Governor.
     arguments: year
     ruby: |
-      if year < 2006
-        nil
-      else
-        Date.civil(year, 3, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 3, :second, :monday))
-      end
+      Date.civil(year, 3, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 3, :second, :monday))
   may_pub_hol_sa:
     # http://www.safework.sa.gov.au/show_page.jsp?id=2483#.VQ9Mfmb8-8E
     # The Holidays Act 1910 provides for the third Monday in May to be a public holiday. Since 2006 this public holiday has been observed on the second Monday in March through the issuing of a special Proclamation by the Governor.
     arguments: year
     ruby: |
-      if year >= 2006
-        nil
-      else
-        Date.civil(year, 5, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, :third, :monday))
-      end
+      Date.civil(year, 5, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, :third, :monday))
   qld_brisbane_ekka_holiday:
     # https://www.qld.gov.au/recreation/travel/holidays/public
     # The Ekka holiday occurs on the Wednesday during the RNA Show perido, the RNA show occurs on the first Friday of August, unless that's prior to August 5, then it occurs on the second.
@@ -910,3 +901,48 @@ tests:
       regions: ['au_act']
     expect:
       name: "Reconciliation Day"
+  - given:
+      date: '2004-05-17'
+      regions: ["au_sa"]
+    expect:
+      name: "May Public Holiday"
+  - given:
+      date: '2006-03-13'
+      regions: ["au_sa"]
+    expect:
+      name: "March Public Holiday"
+  - given:
+      date: '2006-05-15'
+      regions: ["au_sa"]
+    expect:
+      holiday: false
+  - given:
+      date: '2011-10-03'
+      regions: ["au_qld"]
+    expect:
+      holiday: false
+  - given:
+      date: '2013-05-06'
+      regions: ["au_qld"]
+    expect:
+      holiday: false
+  - given:
+      date: '2013-11-14'
+      regions: ["au_qld_brisbane"]
+    expect:
+      holiday: false
+  - given:
+      date: '2015-05-04'
+      regions: ["au_qld"]
+    expect:
+      holiday: false
+  - given:
+      date: '2016-06-13'
+      regions: ["au_qld"]
+    expect:
+      holiday: false
+  - given:
+      date: '2024-10-07'
+      regions: ["au_qld"]
+    expect:
+      name: "King's Birthday"

--- a/pl.yaml
+++ b/pl.yaml
@@ -61,11 +61,15 @@ months:
     mday: 1
   - name: Objawienie Pańskie (święto Trzech Króli)
     regions: [pl]
-    function: pl_trzech_kroli(year)
+    mday: 6
+    year_ranges:
+      from: 2011
   - name: Objawienie Pańskie (święto Trzech Króli)
     regions: [pl]
-    function: pl_trzech_kroli_informal(year)
+    mday: 6
     type: informal
+    year_ranges:
+      until: 2010
   - name: Dzień Babci
     regions: [pl]
     mday: 21
@@ -179,18 +183,6 @@ months:
     regions: [pl]
     mday: 31
     type: informal
-
-methods:
-  pl_trzech_kroli:
-    # Poland: January 6 is holiday since 2011
-    arguments: year
-    ruby: |
-      year >= 2011 ? 6 : nil
-  pl_trzech_kroli_informal:
-    # Poland: January 6 wasn't holiday before 2011
-    arguments: year
-    ruby: |
-      year < 2011 ? 6 : nil
 
 tests:
   - given:
@@ -467,6 +459,12 @@ tests:
   - given:
       date: '2011-01-06'
       regions: ["pl"]
+    expect:
+      name: "Objawienie Pańskie (święto Trzech Króli)"
+  - given:
+      date: '2011-01-06'
+      regions: ["pl"]
+      options: ["informal"]
     expect:
       name: "Objawienie Pańskie (święto Trzech Króli)"
   - given:


### PR DESCRIPTION
## Summary

- Converts all functions that returned `nil` purely as a year-range gate to use the `year_ranges` definition field instead
- Simplifies or removes the affected custom methods now that the year logic lives in the definition
- Adds boundary tests for every changed year range in both `pl.yaml` and `au.yaml`

## Changes

**pl.yaml**
- Removes `pl_trzech_kroli` and `pl_trzech_kroli_informal` functions; replaces with `mday: 6` + `year_ranges: from: 2011` / `until: 2010`

**au.yaml**
- `march_pub_hol_sa`: adds `year_ranges: from: 2006`; simplifies function
- `may_pub_hol_sa`: adds `year_ranges: until: 2005`; simplifies function
- `qld_queens_birthday_june`: adds `year_ranges: until: 2015`; simplifies function
- `qld_labour_day_may`: splits into two definitions (`until: 2012`, `from: 2016`); simplifies function
- `qld_labour_day_october`: adds `year_ranges: between: {start: 2013, end: 2015}`; simplifies function
- `qld_queens_bday_october`: splits into `mday: 1` + `limited: [2012]` and function + `between: {start: 2016, end: 2022}`; simplifies function
- `qld_kings_bday_october`: already had `year_ranges: from: 2023`; drops nil branch from function
- `g20_day_2014_only`: removes function entirely; replaces with `mday: 14` + `limited: [2014]`

## What was not changed

Functions where `nil` is a legitimate computation result (not a year gate) are left as-is: `jp_citizens_holiday`, `jp_substitute_holiday`, `us_inauguration_day`, `even_year_election_day`.

## Test plan

- [x] All existing tests pass
- [x] New boundary tests added for every changed year range