### PR TITLE
Clarify that formal holidays are what is commonly called statutory holidays

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Currently it is only used by the [existing Holidays gem](https://github.com/holi
 definitions and generates ruby classes for use in that gem. In the future it will be used by other languages in
 a similar manner.
 
+By default the definitions in this repository represent **statutory holidays** — government-defined observances. Holidays that are culturally recognized but not enshrined in law (such as Valentine's Day) are marked `type: informal` and are only returned when the consumer explicitly requests them. See the [Syntax Guide](doc/SYNTAX.md#formalinformal) for details.
+
 **Please note** that this is _not_ a gem. The validation process is written in ruby simply for convenience. The real
 stars of this show are the YAML files.
 

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -37,7 +37,7 @@ Non-standard regions (e.g. `ecbtarget`, `federalreserve`, etc) must be all one w
 
 #### `formal`/`informal`
 
-We consider `formal` dates as government-defined holidays. These could be the kinds of holidays where everyone stays home from work or perhaps are bank holidays but it is *not required* for a holiday to have these features to be considered formal.
+We consider `formal` dates as government-defined holidays — what is commonly called **statutory** holidays. These could be the kinds of holidays where everyone stays home from work or perhaps are bank holidays but it is *not required* for a holiday to have these features to be considered formal.
 
 `Informal` holidays are holidays that everyone knows about but aren't enshrined in law. For example, Valentine's Day in the US is considered an informal holiday.
 


### PR DESCRIPTION
## Summary

- Updates `README.md` to explain that definitions in this repo represent statutory holidays by default, with `type: informal` as the explicit opt-in for culturally recognized but non-statutory holidays
- Updates `doc/SYNTAX.md` to connect the `formal` term to the more commonly used word "statutory" so contributors understand the relationship between the two

## Test plan

- [ ] Review README and SYNTAX.md changes for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)