### PR TITLE
Fix NZ Canterbury Anniversary Day to second Friday after first Tuesday of November

### DIFF
--- a/nz.yaml
+++ b/nz.yaml
@@ -101,8 +101,7 @@ months:
   11:
   - name: Canterbury Anniversary Day
     regions: [nz_ca]
-    week: 2
-    wday: 5
+    function: nz_canterbury_anniversary(year)
   - name: Chatham Island Anniversary Day
     regions: [nz_ch]
     mday: 30
@@ -282,6 +281,21 @@ tests:
       regions: ["nz"]
     expect:
       name: "King's Birthday"
+  - given:
+      date: "2023-11-17"
+      regions: ["nz_ca"]
+    expect:
+      name: "Canterbury Anniversary Day"
+  - given:
+      date: "2024-11-15"
+      regions: ["nz_ca"]
+    expect:
+      name: "Canterbury Anniversary Day"
+  - given:
+      date: "2028-11-17"
+      regions: ["nz_ca"]
+    expect:
+      name: "Canterbury Anniversary Day"
 
 
 methods:
@@ -303,6 +317,16 @@ methods:
   next_week:
     arguments: date
     ruby: |
+      date + 7
+  nz_canterbury_anniversary:
+    # Canterbury Anniversary Day (Christchurch Show Day) falls on the second
+    # Friday after the first Tuesday of November.
+    arguments: year
+    ruby: |
+      date = Date.civil(year, 11, 1)
+      date += 1 until date.tuesday?
+      date += 1
+      date += 1 until date.friday?
       date + 7
   matariki:
     # Matariki is based on the Māori lunar calendar (similar to Easter) so can't be


### PR DESCRIPTION
Fix for https://github.com/holidays/holidays/issues/285