### PR TITLE
Add new Colombian holiday: Día de Nuestra Señora del Rosario de Chiquinquirá (Law 2578 of 2026)

### DIFF
--- a/co.yaml
+++ b/co.yaml
@@ -1,6 +1,6 @@
 # Colombian holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2018-06-01.
+# Updated: 2026-07-10.
 #
 # Sources:
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Colombia
@@ -9,6 +9,7 @@
 # - https://www.officeholidays.com/countries/colombia/
 # - https://www.timeanddate.com/holidays/colombia/
 # - http://www.bank-holidays.com/country/Colombia_42.htm
+# - https://www.mininterior.gov.co/noticias/gobierno-sanciona-ley-que-convierte-el-9-de-julio-en-nuevo-festivo-nacional/
 ---
 region_names:
   co: "Colombia"
@@ -47,6 +48,16 @@ methods:
     arguments: year
     ruby: |
       date = Date.civil( year, 6, 29 )
+      if date.wday > 1
+        date += ( 8 - date.wday )
+      elsif date.wday == 0
+        date += 1
+      end
+      date
+  our_lady_of_chiquinquira:
+    arguments: year
+    ruby: |
+      date = Date.civil( year, 7, 9 )
       if date.wday > 1
         date += ( 8 - date.wday )
       elsif date.wday == 0
@@ -135,6 +146,12 @@ months:
     regions: [co]
     function: saint_peter_and_saint_paul(year)
   7:
+  # National holiday since 2026, established by Law 2578 of 2026.
+  - name: Día de Nuestra Señora del Rosario de Chiquinquirá
+    regions: [co]
+    function: our_lady_of_chiquinquira(year)
+    year_ranges:
+      from: 2026
   - name: Día de la Independencia
     regions: [co]
     mday: 20
@@ -309,6 +326,27 @@ tests:
       regions: ['co']
     expect:
       name: 'San Pedro y San Pablo'
+  # Día de Nuestra Señora del Rosario de Chiquinquirá
+  - given:
+      date: '2026-07-13'
+      regions: ['co']
+    expect:
+      name: 'Día de Nuestra Señora del Rosario de Chiquinquirá'
+  - given:
+      date: '2027-07-12'
+      regions: ['co']
+    expect:
+      name: 'Día de Nuestra Señora del Rosario de Chiquinquirá'
+  - given:
+      date: '2029-07-09'
+      regions: ['co']
+    expect:
+      name: 'Día de Nuestra Señora del Rosario de Chiquinquirá'
+  - given:
+      date: '2025-07-14'
+      regions: ['co']
+    expect:
+      holiday: false
   # Día de la Independencia
   - given:
       date: '2014-07-20'


### PR DESCRIPTION
## Summary

Colombia has a new statutory national holiday: **Día de Nuestra Señora del Rosario de Chiquinquirá** (July 9), established by [Law 2578 of June 1, 2026](https://www.mininterior.gov.co/noticias/gobierno-sanciona-ley-que-convierte-el-9-de-julio-en-nuevo-festivo-nacional/). It is a paid national holiday effective from 2026.

Like several other Colombian holidays (per the "Emiliani law"), when July 9 does not fall on a Monday the observance moves to the following Monday. For example, in 2026 July 9 falls on a Thursday, so it is observed on Monday, July 13, 2026 — as confirmed by the official government announcement.

## Changes

- New custom method `our_lady_of_chiquinquira`, following the exact same pattern as the other movable Colombian holidays in `co.yaml` (`epiphany`, `saint_josephs_day`, etc.).
- New `months` entry under month 7 with `year_ranges: from: 2026`, since the law only takes effect in 2026.
- Added the official government source to the file header.
- Tests:
  - `2026-07-13` (July 9 is a Thursday → observed Monday, matching the official announcement)
  - `2027-07-12` (July 9 is a Friday → observed Monday)
  - `2029-07-09` (July 9 falls on a Monday → observed same day)
  - `2025-07-14` expects no holiday (before the law took effect)

## Validation

`ruby lib/validation/run.rb` passes for `co.yaml`. Note that on current master the full run fails later on `mc.yaml` with `region_names is required` — that failure is unrelated to this change (it also occurs on a clean checkout of master).
