### PR TITLE
Add required region_names to mc.yaml

### DIFF
--- a/mc.yaml
+++ b/mc.yaml
@@ -7,6 +7,8 @@
 # When New Year's Day, May 1st, Assumption, All Saints' Day, Prince's Day, or Christmas
 # fall on a Sunday, the following Monday is a holiday.
 ---
+region_names:
+  mc: "Monaco"
 months:
   0:
   - name: Lundi de Pâques


### PR DESCRIPTION
## Summary

`mc.yaml` (Monaco) is missing the now-required `region_names` key, so `make validate` fails on a clean checkout with `region_names is required` (introduced by the strict region_names validation in #341/#342). This halts validation before any later file is checked.

This adds the missing entry:

```yaml
region_names:
  mc: "Monaco"
```

The value matches the ISO 3166 `common_name` for `MC` that the validator checks against.

## Verification

- `make validate` -> `Success! Definition count: 79` (previously halted at mc.yaml)
- Full holidays gem test suite: 483 tests, 8517 assertions, 0 failures