### PR TITLE
Fix ph_heroes_day when Aug 31 falls on a Sunday

### DIFF
--- a/ph.yaml
+++ b/ph.yaml
@@ -77,11 +77,7 @@ methods:
     arguments: year
     ruby: |
       date = Date.new(year, 8, -1)
-
-      if date.wday != 1
-        date -= date.wday - 1
-      end
-
+      date -= (date.wday - 1) % 7
       date
 
 tests:
@@ -112,6 +108,11 @@ tests:
       name: "Ninoy Aquino Day"
   - given:
       date: '2015-08-31'
+      regions: ["ph"]
+    expect:
+      name: "National Heroes Day"
+  - given:
+      date: '2025-08-25'
       regions: ["ph"]
     expect:
       name: "National Heroes Day"


### PR DESCRIPTION
## Summary

Fixes #345.

`ph_heroes_day` is documented as "last Monday of August" but returns **September 1** in years where August 31 falls on a Sunday. Ruby's `wday` is `Sun=0, Mon=1, ...`, so the walk-back `date -= date.wday - 1` becomes `date -= -1` for Sunday, stepping *forward* to Sept 1 instead of back to the last Monday.

Affected years (1970-2030): 1975, 1980, 1986, 1997, 2003, 2008, 2014, 2025, all output Sep 01 instead of Aug 25.

## Fix

Use a non-negative modulo so Sunday maps to a 6-day walk-back, which also removes the need for the `if` guard:

```ruby
date = Date.new(year, 8, -1)
date -= (date.wday - 1) % 7
date
```

For Sunday: `(0 - 1) % 7 == 6` -> Aug 25. For Monday: `(1 - 1) % 7 == 0` -> unchanged.

## Verification

- Confirmed all 8 affected years now return the last Monday of August.
- Philippines' National Heroes Day is statutorily the last Monday of August (Republic Act No. 9492).
- Added a regression test for 2025-08-25.
- Full holidays gem test suite: 483 tests, 8517 assertions, 0 failures (ph region: 10 assertions, 0 failures).