### PR TITLE
Add gov.uk-verified GB winter substitute day tests for 2021, 2023, 2027 and 2028

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -605,3 +605,246 @@ tests:
       regions: ["gb"]
     expect:
       name: "Bank Holiday for the Coronation of King Charles III"
+  # Winter substitute days verified against https://www.gov.uk/bank-holidays.json
+  # Covers New Year's Day, 2nd January, Christmas Day and Boxing Day across
+  # gb_eng, gb_nir and gb_sct for 2021, 2023, 2027 and 2028.
+  - given:
+      date: '2021-01-01'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2021-01-01'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2021-01-01'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2021-01-04'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "2nd January"
+  - given:
+      date: '2021-12-27'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2021-12-27'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2021-12-27'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2021-12-28'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2021-12-28'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2021-12-28'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2023-01-02'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2023-01-02'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2023-01-02'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2023-01-03'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "2nd January"
+  - given:
+      date: '2023-12-25'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2023-12-25'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2023-12-25'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2023-12-26'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2023-12-26'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2023-12-26'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2027-01-01'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2027-01-01'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2027-01-01'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2027-01-04'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "2nd January"
+  - given:
+      date: '2027-12-27'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2027-12-27'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2027-12-27'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2027-12-28'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2027-12-28'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2027-12-28'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2028-01-03'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2028-01-03'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2028-01-03'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: '2028-01-04'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "2nd January"
+  - given:
+      date: '2028-12-25'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2028-12-25'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2028-12-25'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+  - given:
+      date: '2028-12-26'
+      regions: ["gb_eng"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2028-12-26'
+      regions: ["gb_nir"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"
+  - given:
+      date: '2028-12-26'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "Boxing Day"


### PR DESCRIPTION
Follow-up to #343 and to holidays/holidays#396.

## Why

While verifying whether Scotland had a New Year analogue of the Christmas/Boxing swap fixed in #343, two coverage gaps turned up in `gb.yaml`:

1. Winter substitute-day tests stop at 2022. Existing cases run 2008-2022 only.
2. `gb_eng` and `gb_nir` have no New Year substitute coverage at all. Only `gb` and `gb_sct` are exercised.

The behaviour itself is correct. A full comparison of all 280 official UK bank holidays for 2019-2028 across the three divisions found every one of the 38 December/January substitute days already right, and no New Year swap exists. These tests lock that in rather than change anything.

## What this adds

40 cases covering New Year's Day, 2nd January, Christmas Day and Boxing Day across `gb_eng`, `gb_nir` and `gb_sct` for 2021, 2023, 2027 and 2028.

Every expectation is taken from https://www.gov.uk/bank-holidays.json, not hand-derived. The years were chosen to cover the distinct weekend alignments that trigger substitution:

| year | alignment | exercises |
|---|---|---|
| 2021 | Jan 2 Sat, Dec 25 Sat | 2nd January alone shifts; Christmas and Boxing both shift |
| 2023 | Jan 1 Sun, Dec 25 Mon | New Year and 2nd January both shift; December control case |
| 2027 | Jan 2 Sat, Dec 25 Sat | repeat of the 2021 alignment in a later cycle |
| 2028 | Jan 1 Sat, Dec 25 Mon | New Year shifts by 2; December control case |

This also pins the asymmetry between the two rules, which is what made #396 subtle: when Jan 1 is a Sunday both New Year and 2nd January shift, but when Dec 25 is a Sunday, Boxing Day keeps the Monday and Christmas leapfrogs it to Tuesday.

## Deliberately not included

Nothing beyond 2028. The gov.uk feed ends at 2028-12-26, so later years would encode extrapolation as if it were verified fact, and would quietly cement a wrong expectation if the rules ever changed.

For what it is worth, checking the gem's output for 2029-2035 by weekday-alignment class found all 14 classes internally consistent, with 13 anchored by a gov.uk-verified year. The one unanchored class is Christmas on a Tuesday (2029, 2035), where no substitution occurs at all. So the later years appear correct; they are simply not independently verifiable, and add no new logic.

## Verification

- All 40 expectations checked against the current gem before commit: 40 pass, 0 fail.
- `rake generate` then `rake test_region gb`: 119 assertions, 0 failures (up from 79).
- `rake test:contract`: 99 tests, 7994 assertions, 0 failures.