### PR TITLE
Add Scotland World Cup bank holiday for 15 June 2026

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -115,6 +115,15 @@ months:
     mday: 3
     year_ranges:
       limited: [2022]
+  # One-off bank holiday in Scotland only, appointed by Royal Proclamation of
+  # 3 February 2026 under section 1(3) of the Banking and Financial Dealings
+  # Act 1971, marking Scotland's men's football team reaching the FIFA World
+  # Cup for the first time in 28 years.
+  - name: World Cup Bank Holiday
+    regions: [gb_sct]
+    mday: 15
+    year_ranges:
+      limited: [2026]
   7:
   - name: Tynwald Day
     regions: [im, gb_iom]
@@ -848,3 +857,31 @@ tests:
       options: ["observed"]
     expect:
       name: "Boxing Day"
+  # World Cup bank holiday, Scotland only, 2026 only (Royal Proclamation of
+  # 3 February 2026). Confirmed against https://www.gov.uk/bank-holidays.json
+  - given:
+      date: '2026-06-15'
+      regions: ["gb_sct"]
+      options: ["observed"]
+    expect:
+      name: "World Cup Bank Holiday"
+  - given:
+      date: '2026-06-15'
+      regions: ["gb_eng"]
+    expect:
+      holiday: false
+  - given:
+      date: '2026-06-15'
+      regions: ["gb_nir"]
+    expect:
+      holiday: false
+  - given:
+      date: '2025-06-15'
+      regions: ["gb_sct"]
+    expect:
+      holiday: false
+  - given:
+      date: '2027-06-15'
+      regions: ["gb_sct"]
+    expect:
+      holiday: false


### PR DESCRIPTION
## What

Adds the one-off `World Cup Bank Holiday` on 2026-06-15 for `gb_sct`. The gem currently returns nothing for that date.

## Source

Appointed by Royal Proclamation, given at Buckingham Palace on 3 February 2026, under section 1(3) of the Banking and Financial Dealings Act 1971:

> APPOINTING MONDAY, 15TH JUNE 2026, AS A BANK HOLIDAY IN SCOTLAND
>
> Whereas, to mark the achievement of Scotland's men's football team competing at the FIFA World Cup for the first time in 28 years, We consider it desirable that Monday, the fifteenth day of June in the year 2026 should be a bank holiday in Scotland.

Corroborated by https://www.gov.uk/bank-holidays.json, which lists "World Cup bank holiday" on 2026-06-15 under the `scotland` division only, and by the Scottish Government announcement.

**Scotland only.** The proclamation is explicit, and the gov.uk feed has no matching entry for england-and-wales or northern-ireland.

## How it was found

While verifying an unrelated report about Scottish New Year substitute days, I compared the gem against all 280 official UK bank holidays for 2019-2028 across `gb_eng`, `gb_sct` and `gb_nir`. This was the single date-level gap. With this change the comparison is 280/280.

## Change

Uses the existing `year_ranges: limited:` pattern already used for the Platinum Jubilee and the Coronation:

```yaml
  - name: World Cup Bank Holiday
    regions: [gb_sct]
    mday: 15
    year_ranges:
      limited: [2026]
```

Five test cases: the positive case, negative cases for `gb_eng` and `gb_nir` on the same date, and negative cases for `gb_sct` in 2025 and 2027 to pin the year to 2026 only.

## Verification

- `rake test_region gb`: 124 assertions, 0 failures (up from 119)
- `rake test:contract`: 99 tests, 8018 assertions, 0 failures, 0 errors
- full gov.uk comparison: 280 checked, 0 missing (was 1)
- spot check: `gb_sct` 2026-06-15 returns "World Cup Bank Holiday"; `gb_eng`, `gb` and `gb_sct` 2027 all return nothing

## Note on naming

gov.uk styles it "World Cup bank holiday"; I used "World Cup Bank Holiday" to match the capitalisation of neighbouring entries such as "Platinum Jubilee". Happy to change if you prefer the gov.uk casing.