### PR TITLE
Pin GitHub Actions to Node 24 compatible SHAs

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout definitions
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
         with:
           path: definitions-src
 
@@ -20,7 +20,7 @@ jobs:
         run: git clone https://github.com/holidays/holidays.git holidays
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f #v1.306.0
         with:
           ruby-version: 'ruby'
           working-directory: holidays

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - name: Check CHANGELOG has entry for VERSION.txt
         run: |
           VERSION=$(cat VERSION.txt)
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,9 +13,9 @@ jobs:
        matrix:
          ruby: ['3.3', '3.4', '4.0', 'ruby-head']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f #v1.306.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Why

Every workflow run in this repo currently emits:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Node 20 is removed from runners on **2026-09-16**, so `actions/checkout@v4` will stop working then. That would take out `ruby.yml`, `downstream.yml` and `release.yml` together, including the release job.

## Change

- `actions/checkout@v4` -> `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5.0.1), 4 occurrences
- `ruby/setup-ruby@v1` -> `ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f` (v1.306.0), 2 occurrences

These are the exact SHAs already pinned in the holidays gem repo, so both repos now agree.

Pinning by SHA rather than floating tag also closes a supply-chain gap: `@v1` and `@v4` are mutable and can be repointed by the action owner or a compromised account. Every workflow in the gem repo is already SHA-pinned; this brings definitions in line.

## Verification

All three workflow files parse as valid YAML. No logic, trigger or step ordering changed, only the action references.

CI on this PR exercises `ruby.yml` and `downstream.yml` directly. `release.yml` only runs post-merge on master, so its two `checkout` references are changed identically but not exercised here.