### PR TITLE
Update holidays based on Peru’s official public holidays

### DIFF
--- a/pe.yaml
+++ b/pe.yaml
@@ -51,10 +51,9 @@ months:
     wday: 0
     type: informal
   6:
-  - name: Día de la Bandera
+  - name: Batalla de Arica y Día de la Bandera
     regions: [pe]
     mday: 7
-    type: informal
   - name: Día del Padre
     regions: [pe]
     week: 3
@@ -64,10 +63,13 @@ months:
     regions: [pe]
     mday: 24
     type: informal
-  - name: San Pablo y San Pedro
+  - name: Día de San Pedro y San Pablo
     regions: [pe]
     mday: 29
   7:
+  - name: Día de la Fuerza Aérea del Perú
+    regions: [pe]
+    mday: 23
   - name: Primer Día de la Independencia
     regions: [pe]
     mday: 28
@@ -78,13 +80,8 @@ months:
   - name: Santa Rosa de Lima
     regions: [pe]
     mday: 30
-  9:
-  - name: Día de las Fuerzas Armadas
-    regions: [pe]
-    mday: 24
-    type: informal
   10:
-  - name: Batalla de Angamos
+  - name: Combate de Angamos
     regions: [pe]
     mday: 8
   11:
@@ -96,6 +93,9 @@ months:
     regions: [pe]
     mday: 8
     observed: to_monday_if_sunday(date)
+  - name: Batalla de Ayacucho
+    regions: [pe]
+    mday: 9
   - name: Navidad del Señor
     regions: [pe]
     mday: 25
@@ -148,7 +148,7 @@ tests:
       regions: ["pe"]
       options: ["informal"]
     expect:
-      name: "Día de la Bandera"
+      name: "Batalla de Arica y Día de la Bandera"
   - given:
       date: '2016-06-19'
       regions: ["pe"]
@@ -160,7 +160,7 @@ tests:
       regions: ["pe"]
       options: ["informal"]
     expect:
-      name: "San Pablo y San Pedro"
+      name: "Día de San Pedro y San Pablo"
   - given:
       date: '2016-07-28'
       regions: ["pe"]
@@ -180,17 +180,11 @@ tests:
     expect:
       name: "Santa Rosa de Lima"
   - given:
-      date: '2016-09-24'
-      regions: ["pe"]
-      options: ["informal"]
-    expect:
-      name: "Día de las Fuerzas Armadas"
-  - given:
       date: '2016-10-08'
       regions: ["pe"]
       options: ["informal"]
     expect:
-      name: "Batalla de Angamos"
+      name: "Combate de Angamos"
   - given:
       date: '2016-11-01'
       regions: ["pe"]


### PR DESCRIPTION
Dates have been updated in line with Peru's official public holiday calendar

https://www.gob.pe/feriados
https://www.gob.pe/feriados/historicos