### PR TITLE
Fix sg observed rule so Saturday holidays are not shifted to Friday

### DIFF
--- a/sg.yaml
+++ b/sg.yaml
@@ -30,7 +30,7 @@ months:
   - name: New Year's Day
     regions: [sg]
     mday: 1
-    observed: to_weekday_if_weekend(date)
+    observed: to_monday_if_sunday(date)
   - name: Chinese New Year
     regions: [sg]
     function: lunar_to_solar(year, month, day, region)
@@ -224,7 +224,7 @@ months:
   - name: National Day
     regions: [sg]
     mday: 9
-    observed: to_weekday_if_weekend(date)
+    observed: to_monday_if_sunday(date)
   - name: Hari Raya Haji
     regions: [sg]
     mday: 22
@@ -310,7 +310,7 @@ months:
   - name: Christmas Day
     regions: [sg]
     mday: 25
-    observed: to_weekday_if_weekend(date)
+    observed: to_monday_if_sunday(date)
 
 tests:
   - given:
@@ -436,3 +436,56 @@ tests:
       regions: ["sg"]
     expect:
       holiday: false
+
+  # Observed rule (MOM): a public holiday falling on a Sunday moves to the
+  # following Monday. A Saturday holiday gets no substitute and stays put.
+  # https://www.mom.gov.sg/employment-practices/public-holidays
+
+  # Saturday: the holiday stays on the Saturday.
+  - given:
+      date: ['2022-01-01', '2028-01-01', '2033-01-01']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: ['2025-08-09', '2031-08-09']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "National Day"
+  - given:
+      date: ['2021-12-25', '2027-12-25', '2032-12-25']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"
+
+  # Saturday: no substitute is created on the preceding Friday.
+  - given:
+      date: ['2021-12-31', '2027-12-31', '2032-12-31', '2025-08-08',
+             '2031-08-08', '2021-12-24', '2027-12-24', '2032-12-24']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      holiday: false
+
+  # Sunday: the substitute falls on the following Monday.
+  - given:
+      date: ['2017-01-02', '2023-01-02', '2034-01-02']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "New Year's Day"
+  - given:
+      date: ['2015-08-10', '2020-08-10', '2026-08-10']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "National Day"
+  - given:
+      date: ['2016-12-26', '2022-12-26', '2033-12-26']
+      regions: ["sg"]
+      options: ["observed"]
+    expect:
+      name: "Christmas Day"


### PR DESCRIPTION
Fixes https://github.com/holidays/holidays/issues/488.

## Why

Three `sg.yaml` entries declare `observed: to_weekday_if_weekend(date)`, which moves a Saturday holiday **backward** to the preceding Friday. Singapore has no such rule.

Per the [Ministry of Manpower](https://www.mom.gov.sg/employment-practices/public-holidays):

> If a public holiday falls on a Sunday, the following Monday will be a public holiday.

There is no provision for Saturday, and the [data.gov.sg dataset](https://data.gov.sg/datasets/d_3751791452397f1b1c80c451447e40b7/view) confirms it: National Day 2025 is listed as Saturday 2025-08-09 with no Friday substitute.

The 42 Singapore entries added in #338 already use `to_monday_if_sunday(date)`, so the file was inconsistent with itself. This brings the three older entries in line with the newer ones.

## What changes

`observed: to_weekday_if_weekend(date)` → `observed: to_monday_if_sunday(date)` for New Year's Day, National Day and Christmas Day.

Every Saturday occurrence in 2015-2035 was wrong before this change; there were no correct ones:

| holiday | actual date (Sat) | before | after |
|---|---|---|---|
| Christmas Day 2021 | 2021-12-25 | 2021-12-24 | 2021-12-25 |
| New Year's Day 2022 | 2022-01-01 | 2021-12-31 | 2022-01-01 |
| National Day 2025 | 2025-08-09 | 2025-08-08 | 2025-08-09 |
| Christmas Day 2027 | 2027-12-25 | 2027-12-24 | 2027-12-25 |
| New Year's Day 2028 | 2028-01-01 | 2027-12-31 | 2028-01-01 |
| National Day 2031 | 2031-08-09 | 2031-08-08 | 2031-08-09 |
| Christmas Day 2032 | 2032-12-25 | 2032-12-24 | 2032-12-25 |
| New Year's Day 2033 | 2033-01-01 | 2032-12-31 | 2033-01-01 |

The New Year's Day cases were the most disruptive: the holiday was emitted in the previous calendar year, so a 2022 query returned no New Year's Day at all.

## Why this is safe in one direction

`to_monday_if_sunday` returns the date unchanged unless `wday == 0`, so it only removes the Saturday shift and cannot disturb Sunday handling. All 9 Sunday occurrences in 2015-2035 already resolved to the correct Monday substitute and still do.

## Tests

Adds three groups covering all 17 weekend occurrences in 2015-2035:

- 8 Saturday dates, expecting the holiday to stay on the Saturday.
- The 8 corresponding Fridays, expecting `holiday: false`, which is what actually pins the regression.
- 9 Sunday-substitute Mondays, locking in the behaviour that must not change.

## Verification

- `rake generate` then `rake test_region sg`: 46 assertions, 0 failures.
- `rake test:contract`: 99 tests, 8043 assertions, 0 failures.
- `rake test`: 497 tests, 9247 assertions, 0 failures.
- Direct check across 2015-2035: all 17 weekend occurrences correct, 0 wrong (was 8 wrong).