### PR TITLE
Validate index.yaml naming and file consistency

### DIFF
--- a/lib/validation/error.rb
+++ b/lib/validation/error.rb
@@ -8,5 +8,6 @@ module Definitions
     class InvalidCustomMethod < Error; end
     class InvalidTest < Error; end
     class InvalidRegionNames < Error; end
+    class InvalidIndex < Error; end
   end
 end

--- a/lib/validation/index_validator.rb
+++ b/lib/validation/index_validator.rb
@@ -1,0 +1,105 @@
+require_relative 'error'
+
+module Definitions
+  module Validation
+    class Index
+      # Regions that intentionally have no definition file of their own. They exist
+      # only to bundle other regions' files together, so the '<region>.yaml' naming
+      # rule does not apply to them. Add to this list consciously: a typo'd region
+      # key is otherwise indistinguishable from a new aggregate.
+      AGGREGATE_REGIONS = [
+        'Europe',
+        'NorthAmerica',
+        'Scandinavia',
+        'SouthAmerica',
+      ].freeze
+
+      VALID_FILE_NAME = /\A[a-z0-9_]+\.yaml\z/
+
+      def call(index, definition_files)
+        defs = validate_structure!(index)
+
+        validate_file_names!(defs)
+        validate_all_files_indexed!(defs, definition_files)
+        validate_all_indexed_files_exist!(defs, definition_files)
+        validate_region_file_names!(defs)
+
+        true
+      end
+
+      private
+
+      def validate_structure!(index)
+        raise Errors::InvalidIndex.new("index must be a hash, received: '#{index}'") unless index.is_a?(Hash)
+
+        defs = index['defs']
+
+        raise Errors::InvalidIndex.new("index is missing a 'defs' entry") if defs.nil?
+        raise Errors::InvalidIndex.new("index 'defs' must be a hash, received: '#{defs}'") unless defs.is_a?(Hash)
+        raise Errors::InvalidIndex.new("index 'defs' must not be empty") if defs.empty?
+
+        defs.each do |region, files|
+          unless files.is_a?(Array) && !files.empty?
+            raise Errors::InvalidIndex.new("index entry for '#{region}' must be a non-empty array, received: '#{files}'")
+          end
+        end
+
+        defs
+      end
+
+      def validate_file_names!(defs)
+        invalid = indexed_files(defs).reject { |file| file =~ VALID_FILE_NAME }
+
+        unless invalid.empty?
+          raise Errors::InvalidIndex.new(
+            "index lists files with invalid names: #{invalid.sort.join(', ')}\n" \
+            "Definition file names must be lowercase and end in '.yaml', e.g. 'us.yaml' or 'be_fr.yaml'."
+          )
+        end
+      end
+
+      def validate_all_files_indexed!(defs, definition_files)
+        missing = definition_files - indexed_files(defs)
+
+        unless missing.empty?
+          raise Errors::InvalidIndex.new(
+            "definition files are not listed in index.yaml: #{missing.sort.join(', ')}\n" \
+            "Please add them to the appropriate region entry in index.yaml."
+          )
+        end
+      end
+
+      def validate_all_indexed_files_exist!(defs, definition_files)
+        missing = indexed_files(defs) - definition_files
+
+        unless missing.empty?
+          raise Errors::InvalidIndex.new(
+            "index.yaml lists files that do not exist: #{missing.sort.join(', ')}"
+          )
+        end
+      end
+
+      def validate_region_file_names!(defs)
+        mismatches = defs.reject { |region, files|
+          AGGREGATE_REGIONS.include?(region) || files.include?(expected_file_name(region))
+        }.keys
+
+        unless mismatches.empty?
+          raise Errors::InvalidIndex.new(
+            "index entries do not list their own definition file: " \
+            "#{mismatches.sort.map { |r| "#{r} (expected '#{expected_file_name(r)}')" }.join(', ')}\n" \
+            "A region must list '<region>.yaml' unless it is an aggregate of other regions."
+          )
+        end
+      end
+
+      def expected_file_name(region)
+        "#{region.downcase}.yaml"
+      end
+
+      def indexed_files(defs)
+        defs.values.flatten.uniq
+      end
+    end
+  end
+end

--- a/lib/validation/run.rb
+++ b/lib/validation/run.rb
@@ -5,6 +5,7 @@ require 'countries'
 
 require_relative 'error'
 require_relative 'definition_validator'
+require_relative 'index_validator'
 require_relative 'region_names_validator'
 require_relative 'custom_method_validator'
 require_relative 'month_validator'
@@ -14,33 +15,31 @@ definitions_path = '/../../'
 
 module Definitions
   class Validate
-    def initialize(path, definition_validator)
+    def initialize(path, definition_validator, index_validator)
       @path = path
       @definition_validator = definition_validator
+      @index_validator = index_validator
     end
 
     def call
       path = File.expand_path(File.dirname(__FILE__)) + @path
 
       index_file = YAML.load(File.open(path + 'index.yaml'))
-      indexed_files = index_file['defs'].values.flatten.uniq
+      definition_files = Dir.glob('*.yaml', base: path) - ['index.yaml']
+
+      begin
+        @index_validator.call(index_file, definition_files)
+      rescue Definitions::Errors::InvalidIndex => e
+        puts "Failed on 'index.yaml', error: #{e}"
+        exit 1
+      end
 
       definition_count = 0
 
-      Dir.foreach(path) do |item|
-        next if item == '.' or item == '..'
-
+      definition_files.each do |item|
         target = path+item
-        next if File.extname(target) != '.yaml'
-        next if item == 'index.yaml'
 
         definition_count += 1
-
-        unless indexed_files.include?(item)
-          puts "Failed! Definition file '#{item}' is not listed in index.yaml."
-          puts "Please add '#{item}' to the appropriate region entry in index.yaml."
-          exit 1
-        end
 
         begin
           definition_file = YAML.load(File.open(target))
@@ -86,4 +85,5 @@ Definitions::Validate.new(
     Definitions::Validation::Month.new,
     Definitions::Validation::Test.new,
   ),
+  Definitions::Validation::Index.new,
 ).call

--- a/spec/validation/index_validator_spec.rb
+++ b/spec/validation/index_validator_spec.rb
@@ -1,0 +1,170 @@
+require 'spec_helper'
+require 'validation/index_validator'
+
+describe Definitions::Validation::Index do
+  subject { described_class.new }
+
+  let(:index) { { 'defs' => { 'US' => ['us.yaml'], 'CA' => ['ca.yaml'] } } }
+  let(:definition_files) { ['us.yaml', 'ca.yaml'] }
+
+  context 'valid' do
+    it 'returns true when the index and the files on disk agree' do
+      expect(subject.call(index, definition_files)).to be true
+    end
+
+    it 'allows a region to list additional files beyond its own' do
+      index = { 'defs' => { 'US' => ['us.yaml', 'northamericainformal.yaml'] } }
+      expect(subject.call(index, ['us.yaml', 'northamericainformal.yaml'])).to be true
+    end
+
+    it 'allows the same file to be listed under multiple regions' do
+      index = { 'defs' => { 'US' => ['us.yaml'], 'NorthAmerica' => ['us.yaml'] } }
+      expect(subject.call(index, ['us.yaml'])).to be true
+    end
+
+    it 'allows aggregate regions to have no definition file of their own' do
+      index = {
+        'defs' => {
+          'Europe' => ['fr.yaml'],
+          'NorthAmerica' => ['us.yaml'],
+          'Scandinavia' => ['no.yaml'],
+          'SouthAmerica' => ['br.yaml'],
+          'FR' => ['fr.yaml'],
+          'US' => ['us.yaml'],
+          'NO' => ['no.yaml'],
+          'BR' => ['br.yaml'],
+        }
+      }
+      expect(subject.call(index, ['fr.yaml', 'us.yaml', 'no.yaml', 'br.yaml'])).to be true
+    end
+
+    it 'matches mixed case region keys against their lowercase file names' do
+      index = { 'defs' => { 'FederalReserve' => ['federalreserve.yaml'] } }
+      expect(subject.call(index, ['federalreserve.yaml'])).to be true
+    end
+
+    it 'allows underscores in region keys and file names' do
+      index = { 'defs' => { 'BE_FR' => ['be_fr.yaml'] } }
+      expect(subject.call(index, ['be_fr.yaml'])).to be true
+    end
+  end
+
+  context 'invalid structure' do
+    it 'raises error if the index is not a hash' do
+      expect { subject.call('bad', definition_files) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index must be a hash, received: 'bad'")
+      }
+    end
+
+    it 'raises error if the index has no defs entry' do
+      expect { subject.call({}, definition_files) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index is missing a 'defs' entry")
+      }
+    end
+
+    it 'raises error if defs is not a hash' do
+      expect { subject.call({ 'defs' => ['us.yaml'] }, definition_files) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index 'defs' must be a hash, received: '[\"us.yaml\"]'")
+      }
+    end
+
+    it 'raises error if defs is empty' do
+      expect { subject.call({ 'defs' => {} }, definition_files) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index 'defs' must not be empty")
+      }
+    end
+
+    it 'raises error if a region entry is not an array' do
+      index = { 'defs' => { 'US' => 'us.yaml' } }
+      expect { subject.call(index, ['us.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index entry for 'US' must be a non-empty array, received: 'us.yaml'")
+      }
+    end
+
+    it 'raises error if a region entry is an empty array' do
+      index = { 'defs' => { 'US' => [] } }
+      expect { subject.call(index, ['us.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index entry for 'US' must be a non-empty array, received: '[]'")
+      }
+    end
+  end
+
+  context 'invalid file names' do
+    it 'raises error if an indexed file is uppercase' do
+      index = { 'defs' => { 'US' => ['US.yaml'] } }
+      expect { subject.call(index, ['US.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("index lists files with invalid names: US.yaml")
+        expect(e.message).to include("must be lowercase and end in '.yaml'")
+      }
+    end
+
+    it 'raises error if an indexed file uses a dash instead of an underscore' do
+      index = { 'defs' => { 'BE_FR' => ['be-fr.yaml'] } }
+      expect { subject.call(index, ['be-fr.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("index lists files with invalid names: be-fr.yaml")
+      }
+    end
+
+    it 'raises error if an indexed file has the wrong extension' do
+      index = { 'defs' => { 'US' => ['us.yml'] } }
+      expect { subject.call(index, ['us.yml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("index lists files with invalid names: us.yml")
+      }
+    end
+  end
+
+  context 'files missing from the index' do
+    it 'raises error if a definition file on disk is not listed' do
+      expect { subject.call(index, definition_files + ['hk.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("definition files are not listed in index.yaml: hk.yaml")
+        expect(e.message).to include("Please add them to the appropriate region entry in index.yaml.")
+      }
+    end
+
+    it 'reports every unlisted file, sorted' do
+      expect { subject.call(index, definition_files + ['zz.yaml', 'hk.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("definition files are not listed in index.yaml: hk.yaml, zz.yaml")
+      }
+    end
+  end
+
+  context 'indexed files that do not exist' do
+    it 'raises error if the index lists a file that is not on disk' do
+      index = { 'defs' => { 'US' => ['us.yaml'], 'HK' => ['hk.yaml'] } }
+      expect { subject.call(index, ['us.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index.yaml lists files that do not exist: hk.yaml")
+      }
+    end
+
+    it 'reports every missing file, sorted' do
+      index = { 'defs' => { 'US' => ['us.yaml', 'zz.yaml'], 'HK' => ['hk.yaml'] } }
+      expect { subject.call(index, ['us.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to eq("index.yaml lists files that do not exist: hk.yaml, zz.yaml")
+      }
+    end
+  end
+
+  context 'region file name mismatches' do
+    it 'raises error if a region does not list its own definition file' do
+      index = { 'defs' => { 'US' => ['ca.yaml'] } }
+      expect { subject.call(index, ['ca.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("index entries do not list their own definition file: US (expected 'us.yaml')")
+        expect(e.message).to include("unless it is an aggregate of other regions")
+      }
+    end
+
+    it 'reports every mismatched region, sorted' do
+      index = { 'defs' => { 'US' => ['ca.yaml'], 'GB' => ['ca.yaml'] } }
+      expect { subject.call(index, ['ca.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("index entries do not list their own definition file: GB (expected 'gb.yaml'), US (expected 'us.yaml')")
+      }
+    end
+
+    it 'raises error for a region that is not a known aggregate' do
+      index = { 'defs' => { 'Asia' => ['jp.yaml'], 'JP' => ['jp.yaml'] } }
+      expect { subject.call(index, ['jp.yaml']) }.to raise_error(Definitions::Errors::InvalidIndex) { |e|
+        expect(e.message).to include("Asia (expected 'asia.yaml')")
+      }
+    end
+  end
+end


### PR DESCRIPTION
Closes #4.

Adds a `Definitions::Validation::Index` validator, run once by `make validate` before the per-file loop, covering the checks described in #4 and its follow-up comment:

1. Every definition file on disk is listed in `index.yaml`. This existed already as an inline check in `run.rb`; it moves into the validator and now reports all offenders at once instead of the first one.
2. Every file listed in `index.yaml` exists on disk. Previously a typo'd entry passed clean.
3. File names match `[a-z0-9_]+\.yaml`, so `US.yaml` or `be-fr.yaml` is rejected.
4. Each region lists its own `<region>.yaml`, so a typo'd region key is caught.

Check 4 needs an exception for `Europe`, `NorthAmerica`, `Scandinavia` and `SouthAmerica`, which have no definition file of their own and exist only to bundle other regions. These are an explicit `AGGREGATE_REGIONS` allowlist rather than something inferred, so adding a new aggregate is a deliberate act and a typo'd key can't quietly look like one.

No definition data changes were needed: the repo already satisfies all four rules.

`run.rb` also switches from `Dir.foreach` to `Dir.glob` so the file list can be built once and handed to the validator.

## Testing

`make test` passes, 91 examples, 100% line coverage maintained. `make validate` passes with the definition count unchanged at 79.

Each failure mode was also confirmed end-to-end against the real tree by temporarily breaking `index.yaml`:

```
index.yaml lists files that do not exist: typo.yaml
definition files are not listed in index.yaml: stray.yaml
index entries do not list their own definition file: ZAA (expected 'zaa.yaml')
index lists files with invalid names: ZA.yaml
```
