### PR TITLE
Exit non-zero when definition validation fails

### DIFF
--- a/lib/validation/run.rb
+++ b/lib/validation/run.rb
@@ -47,10 +47,10 @@ module Definitions
         rescue Psych::SyntaxError => e
           puts "Failed on file '#{target}', YAML parse error: #{e}"
           puts "This means your YAML is somehow invalid. Test your file on something like yamllint.com to find the issue."
-          exit
+          exit 1
         rescue => e
           puts "Failed on file '#{target}', error: #{e}"
-          exit
+          exit 1
         end
       end
 


### PR DESCRIPTION
`run.rb` used a bare `exit` in both per-file rescue branches. `Kernel#exit` with no argument is status 0, so `make validate` printed the failure and then reported success.

This means the `Run validate` step in `ruby.yml` has never gated anything for per-definition-file errors. Broken definitions have only been caught since the downstream integration job landed (#42), and only to the extent that they break `make generate` or the contract tests.

The index checks added in #356 are unaffected; that path already used `exit 1`.

Found while investigating #124, but this is a bug rather than the readability enhancement that issue is filed as, so it is split out on its own. The rest of #124 follows separately.

## Testing

Reproducing the `ar.yaml` scenario from #124 by changing month `8` to `xyz`:

```
$ bundle exec ruby lib/validation/run.rb > /dev/null 2>&1; echo $?
before: 0
after:  1
```

A file with malformed YAML also now exits non-zero. A clean tree still exits 0, and `make test` passes at 100% line coverage.

Note this has no blast radius: master validates clean today, so turning the gate on does not surface a backlog of hidden failures.
