### PR TITLE
Report all validation errors with actionable messages

### DIFF
--- a/lib/validation/custom_method_validator.rb
+++ b/lib/validation/custom_method_validator.rb
@@ -7,10 +7,20 @@ module Definitions
 
       def call(methods)
         methods.each do |name, method|
-          raise Errors::InvalidCustomMethod unless
-          valid_name?(name) &&
-            valid_arguments?(method['arguments']) &&
-            valid_source?(method['ruby'])
+          unless valid_name?(name)
+            raise Errors::InvalidCustomMethod.new("A custom method is missing a name, received: '#{name}'")
+          end
+
+          unless valid_arguments?(method['arguments'])
+            raise Errors::InvalidCustomMethod.new(
+              "Custom method '#{name}' has invalid arguments: '#{method['arguments']}'. " \
+              "Valid arguments are: #{VALID_ARGUMENTS.join(', ')}"
+            )
+          end
+
+          unless valid_source?(method['ruby'])
+            raise Errors::InvalidCustomMethod.new("Custom method '#{name}' is missing a 'ruby' source block")
+          end
         end
 
         true

--- a/lib/validation/definition_validator.rb
+++ b/lib/validation/definition_validator.rb
@@ -10,13 +10,33 @@ module Definitions
         @test_validator = test_validator
       end
 
+      # Returns every error found in the definition rather than stopping at the first
+      # one, so that a contributor can see problems in 'months', 'methods' and 'tests'
+      # in a single run. Errors are collected per section: the first problem within a
+      # given section still ends that section's validation.
       def call(definition)
-        @region_names_validator.call(definition['region_names'], definition['months'])
-        @months_validator.call(definition['months'])
-        @custom_method_validator.call(definition['methods']) unless definition['methods'].nil?
-        @test_validator.call(definition['tests']) unless definition['tests'].nil?
+        errors = []
 
-        true
+        month_errors = collect { @months_validator.call(definition['months']) }
+        errors.concat(month_errors)
+
+        # region_names coverage is derived from the regions listed in 'months', so it
+        # can only be checked once we know 'months' itself is well formed.
+        errors.concat(collect { @region_names_validator.call(definition['region_names'], definition['months']) }) if month_errors.empty?
+
+        errors.concat(collect { @custom_method_validator.call(definition['methods']) }) unless definition['methods'].nil?
+        errors.concat(collect { @test_validator.call(definition['tests']) }) unless definition['tests'].nil?
+
+        errors
+      end
+
+      private
+
+      def collect
+        yield
+        []
+      rescue Errors::Error => e
+        [e.message]
       end
     end
   end

--- a/lib/validation/month_validator.rb
+++ b/lib/validation/month_validator.rb
@@ -3,55 +3,106 @@ require_relative 'error'
 module Definitions
   module Validation
     class Month
+      VALID_YEAR_RANGE_SELECTORS = ["until", "from", "limited", "between"]
+
       def call(months)
         raise Errors::NoMonths.new("Months is required, received: '#{months}'") if months.nil? || months.empty?
 
         months.each do |month, month_defs|
-          raise Errors::InvalidMonth.new("All months must be an integer, received: #{months}") unless month.is_a?(Integer)
-          raise Errors::InvalidMonth.new("All months must be between 0 and 12, received: #{months}") if month < 0 || month > 12
+          raise Errors::InvalidMonth.new("Month key must be an integer, received: '#{month}'") unless month.is_a?(Integer)
+          raise Errors::InvalidMonth.new("Month key must be between 0 and 12, received: '#{month}'") if month < 0 || month > 12
 
           month_defs.each do |month_def|
-            raise Errors::InvalidMonth.new("All months must have a name, received: #{months}") if month_def['name'].nil? || month_def['name'].empty?
-
-            raise Errors::InvalidRegions.new("A month must contain at least one region, received: #{months}") if month_def['regions'].nil? || month_def['regions'].empty?
-
-            month_def['regions'].each do |region|
-              raise Errors::InvalidRegions.new("A month must contain at least one region, received: #{months}") if region.nil? || region.empty?
-            end
-
-            if month_def.key?("year_ranges")
-              raise Errors::InvalidMonth.new("year_ranges only supports a single selector at this time, received: #{months}") unless month_def["year_ranges"].is_a?(Hash) && month_def["year_ranges"].size == 1
-
-              selector = month_def["year_ranges"].keys.first
-              value = month_def["year_ranges"][selector]
-
-              raise Errors::InvalidMonth.new("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}") unless [:until, :from, :limited, :between].include?(selector.to_sym)
-
-              case selector
-              when "until"
-                raise Errors::InvalidMonth.new("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value.is_a?(Integer)
-              when "from"
-                raise Errors::InvalidMonth.new("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value.is_a?(Integer)
-              when "limited"
-                raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless value.is_a?(Array)
-
-                value.each do |j|
-                  raise Errors::InvalidMonth.new("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}") unless j.is_a?(Integer)
-                end
-              when "between"
-                raise Errors::InvalidMonth.new("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}") unless value.is_a?(Hash) && value.key?("start") && value.key?("end")
-
-                raise Errors::InvalidMonth.new("The year_ranges.between.start value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value["start"].is_a?(Integer)
-                raise Errors::InvalidMonth.new("The year_ranges.between.end value must contain a single 'year' integer, ex. 2018, received: #{months}") unless value["end"].is_a?(Integer)
-
-                raise Errors::InvalidMonth.new("The year_ranges.between.end value cannot be before the start value, received: #{months}") if value["end"] < value["start"]
-                raise Errors::InvalidMonth.new("The year_ranges.between start and end values cannot be the same, received: #{months}") if value["end"] == value["start"]
-              end
-            end
+            validate_month_def!(month, month_def)
           end
         end
 
         true
+      end
+
+      private
+
+      def validate_month_def!(month, month_def)
+        name = month_def['name']
+
+        raise Errors::InvalidMonth.new("A holiday in month #{month} is missing a 'name', received: #{month_def}") if name.nil? || name.empty?
+
+        validate_regions!(month, name, month_def['regions'])
+        validate_year_ranges!(month, name, month_def['year_ranges']) if month_def.key?("year_ranges")
+      end
+
+      def validate_regions!(month, name, regions)
+        if regions.nil? || regions.empty?
+          raise Errors::InvalidRegions.new("#{context(month, name)} must contain at least one region, received: #{regions.inspect}")
+        end
+
+        regions.each do |region|
+          if region.nil? || region.empty?
+            raise Errors::InvalidRegions.new("#{context(month, name)} contains an empty region, received: #{regions.inspect}")
+          end
+        end
+      end
+
+      def validate_year_ranges!(month, name, year_ranges)
+        unless year_ranges.is_a?(Hash) && year_ranges.size == 1
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges only supports a single selector at this time, received: #{year_ranges.inspect}")
+        end
+
+        selector = year_ranges.keys.first
+        value = year_ranges[selector]
+
+        unless VALID_YEAR_RANGE_SELECTORS.include?(selector.to_s)
+          raise Errors::InvalidMonth.new("#{context(month, name)} has an invalid year_ranges selector '#{selector}'. Valid selectors are: #{VALID_YEAR_RANGE_SELECTORS.join(', ')}")
+        end
+
+        case selector.to_s
+        when "until", "from"
+          unless value.is_a?(Integer)
+            raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.#{selector} must contain a single 'year' integer, ex. 2018, received: #{value.inspect}")
+          end
+        when "limited"
+          validate_limited!(month, name, value)
+        when "between"
+          validate_between!(month, name, value)
+        end
+      end
+
+      def validate_limited!(month, name, value)
+        unless value.is_a?(Array)
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.limited must contain an array of 'year' integers, ex. [2018], received: #{value.inspect}")
+        end
+
+        value.each do |year|
+          unless year.is_a?(Integer)
+            raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.limited must contain only 'year' integers, ex. [2018], received: '#{year}'")
+          end
+        end
+      end
+
+      def validate_between!(month, name, value)
+        unless value.is_a?(Hash) && value.key?("start") && value.key?("end")
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.between must contain both a 'start' and 'end' key, received: #{value.inspect}")
+        end
+
+        unless value["start"].is_a?(Integer)
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.between.start must contain a single 'year' integer, ex. 2018, received: #{value["start"].inspect}")
+        end
+
+        unless value["end"].is_a?(Integer)
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.between.end must contain a single 'year' integer, ex. 2018, received: #{value["end"].inspect}")
+        end
+
+        if value["end"] < value["start"]
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.between.end cannot be before the start value, received start: #{value["start"]}, end: #{value["end"]}")
+        end
+
+        if value["end"] == value["start"]
+          raise Errors::InvalidMonth.new("#{context(month, name)} year_ranges.between start and end values cannot be the same, received: #{value["start"]}")
+        end
+      end
+
+      def context(month, name)
+        "Holiday '#{name}' in month #{month}"
       end
     end
   end

--- a/lib/validation/run.rb
+++ b/lib/validation/run.rb
@@ -25,7 +25,7 @@ module Definitions
       path = File.expand_path(File.dirname(__FILE__)) + @path
 
       index_file = YAML.load(File.open(path + 'index.yaml'))
-      definition_files = Dir.glob('*.yaml', base: path) - ['index.yaml']
+      definition_files = (Dir.glob('*.yaml', base: path) - ['index.yaml']).sort
 
       begin
         @index_validator.call(index_file, definition_files)
@@ -34,34 +34,63 @@ module Definitions
         exit 1
       end
 
-      definition_count = 0
+      puts "Found #{definition_files.size} definition YAML files to check! Starting validation checks ..."
+
+      # Every file is checked on every run so that a contributor sees all of the
+      # problems at once rather than fixing one and rerunning to find the next.
+      failures = {}
 
       definition_files.each do |item|
-        target = path+item
-
-        definition_count += 1
-
-        begin
-          definition_file = YAML.load(File.open(target))
-          validate!(definition_file)
-        rescue Psych::SyntaxError => e
-          puts "Failed on file '#{target}', YAML parse error: #{e}"
-          puts "This means your YAML is somehow invalid. Test your file on something like yamllint.com to find the issue."
-          exit 1
-        rescue => e
-          puts "Failed on file '#{target}', error: #{e}"
-          exit 1
-        end
+        errors = validate_file(path + item)
+        failures[item] = errors unless errors.empty?
       end
 
-      puts "Success!"
-      puts "Definition count: #{definition_count}"
+      report(definition_files, failures)
+
+      exit 1 unless failures.empty?
     end
 
     private
 
-    def validate!(definition)
-      raise StandardError unless @definition_validator.call(definition)
+    def validate_file(target)
+      @definition_validator.call(YAML.load(File.open(target)))
+    rescue Psych::SyntaxError => e
+      [
+        "YAML parse error: #{e}",
+        "This means your YAML is somehow invalid. Test your file on something like yamllint.com to find the issue.",
+      ]
+    rescue => e
+      ["#{e.class}: #{e.message}"]
+    end
+
+    def report(definition_files, failures)
+      puts "Validations complete!"
+      puts
+      puts "Summary"
+      puts "---------"
+      puts "Total files checked: #{definition_files.size}"
+      puts "Passed: #{definition_files.size - failures.size}"
+      puts "Failed: #{failures.size}"
+
+      if failures.empty?
+        puts
+        puts "Success!"
+        return
+      end
+
+      puts "Files containing validation errors: #{failures.keys.map { |file| "'#{file}'" }.join(', ')}"
+      puts
+      puts "Error details by definition file:"
+      puts
+
+      failures.each do |file, errors|
+        puts "----"
+        puts "File: #{file}"
+        puts "Total errors found: #{errors.size}"
+        puts "Details:"
+        errors.each { |error| puts "  #{error}" }
+        puts "----"
+      end
     end
   end
 end

--- a/lib/validation/test_validator.rb
+++ b/lib/validation/test_validator.rb
@@ -68,7 +68,7 @@ module Definitions
       def parse_date!(d)
         DateTime.parse(d)
       rescue TypeError, ArgumentError, NoMethodError
-        err!("Test must contain valid date, date value was: '#{d}")
+        err!("Test must contain valid date, date value was: '#{d}'")
       end
 
       def validate_expect!(e)

--- a/spec/validation/custom_method_validator_spec.rb
+++ b/spec/validation/custom_method_validator_spec.rb
@@ -24,36 +24,48 @@ describe Definitions::Validation::CustomMethod do
       it 'returns false if empty' do
         methods = {}
         methods[""]  = {}
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("A custom method is missing a name, received: ''")
+        }
       end
     end
 
     context 'arguments' do
       it 'returns false if nil' do
         methods['test']['arguments'] = nil
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("Custom method 'test' has invalid arguments: ''. Valid arguments are: date, year, month, day")
+        }
       end
 
       it 'returns false if empty' do
         methods['test']['arguments'] = ""
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("Custom method 'test' has invalid arguments: ''. Valid arguments are: date, year, month, day")
+        }
       end
 
-      it 'returns false if contains unknown variable' do
+      it 'names the method and the offending arguments if it contains an unknown variable' do
         methods['test']['arguments'] = "unknown"
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("Custom method 'test' has invalid arguments: 'unknown'. Valid arguments are: date, year, month, day")
+        }
       end
     end
 
     context 'source' do
       it 'returns false if nil' do
         methods['test']['ruby'] = nil
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("Custom method 'test' is missing a 'ruby' source block")
+        }
       end
 
       it 'returns false if empty' do
         methods['test']['ruby'] = ""
-        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod)
+        expect { subject.call(methods) }.to raise_error(Definitions::Errors::InvalidCustomMethod) { |e|
+          expect(e.message).to eq("Custom method 'test' is missing a 'ruby' source block")
+        }
       end
     end
   end

--- a/spec/validation/definition_validator_spec.rb
+++ b/spec/validation/definition_validator_spec.rb
@@ -17,36 +17,73 @@ describe Definitions::Validation::Definition do
   subject { described_class.new(region_names_validator, custom_method_validator, months_validator, test_validator) }
 
   context 'definition is valid' do
-    it 'reports success' do
-      expect(subject.call(definition)).to be true
+    it 'reports no errors' do
+      expect(subject.call(definition)).to eq([])
     end
   end
 
   context 'invalid region_names' do
-    it 'raises error if region_names validator raises error' do
-      expect(region_names_validator).to receive(:call).with(definition['region_names'], definition['months']).and_raise(StandardError)
-      expect { subject.call(definition) }.to raise_error(StandardError)
+    it 'returns the error raised by the region_names validator' do
+      expect(region_names_validator).to receive(:call).with(definition['region_names'], definition['months']).and_raise(Definitions::Errors::InvalidRegionNames.new("bad region names"))
+      expect(subject.call(definition)).to eq(["bad region names"])
     end
   end
 
   context 'invalid months' do
-    it 'raises error if months validator raises error' do
-      expect(months_validator).to receive(:call).with(definition['months']).and_raise(StandardError)
-      expect { subject.call(definition) }.to raise_error(StandardError)
+    it 'returns the error raised by the months validator' do
+      expect(months_validator).to receive(:call).with(definition['months']).and_raise(Definitions::Errors::InvalidMonth.new("bad months"))
+      expect(subject.call(definition)).to eq(["bad months"])
+    end
+
+    it 'skips region_names validation because it depends on months' do
+      expect(months_validator).to receive(:call).and_raise(Definitions::Errors::InvalidMonth.new("bad months"))
+      expect(region_names_validator).to_not receive(:call)
+      subject.call(definition)
+    end
+  end
+
+  context 'invalid methods' do
+    it 'returns the error raised by the custom method validator' do
+      expect(custom_method_validator).to receive(:call).with(definition['methods']).and_raise(Definitions::Errors::InvalidCustomMethod.new("bad methods"))
+      expect(subject.call(definition)).to eq(["bad methods"])
+    end
+  end
+
+  context 'invalid tests' do
+    it 'returns the error raised by the test validator' do
+      expect(test_validator).to receive(:call).with(definition['tests']).and_raise(Definitions::Errors::InvalidTest.new("bad tests"))
+      expect(subject.call(definition)).to eq(["bad tests"])
+    end
+  end
+
+  context 'multiple invalid sections' do
+    it 'returns every error rather than stopping at the first' do
+      expect(months_validator).to receive(:call).and_raise(Definitions::Errors::InvalidMonth.new("bad months"))
+      expect(custom_method_validator).to receive(:call).and_raise(Definitions::Errors::InvalidCustomMethod.new("bad methods"))
+      expect(test_validator).to receive(:call).and_raise(Definitions::Errors::InvalidTest.new("bad tests"))
+
+      expect(subject.call(definition)).to eq(["bad months", "bad methods", "bad tests"])
     end
   end
 
   context 'no methods' do
-    it 'returns success' do
+    it 'reports no errors' do
       definition["methods"] = nil
-      expect(subject.call(definition)).to be true
+      expect(subject.call(definition)).to eq([])
     end
   end
 
   context 'no tests' do
-    it 'raises error' do
-      expect(test_validator).to receive(:call).with(definition['tests']).and_raise(StandardError)
-      expect { subject.call(definition) }.to raise_error(StandardError)
+    it 'reports no errors' do
+      definition["tests"] = nil
+      expect(subject.call(definition)).to eq([])
+    end
+  end
+
+  context 'unexpected errors' do
+    it 'does not swallow errors that are not validation errors' do
+      expect(months_validator).to receive(:call).and_raise(NoMethodError.new("something is actually broken"))
+      expect { subject.call(definition) }.to raise_error(NoMethodError)
     end
   end
 end

--- a/spec/validation/month_validator_spec.rb
+++ b/spec/validation/month_validator_spec.rb
@@ -24,47 +24,47 @@ describe Definitions::Validation::Month do
     it 'returns error if month not an integer' do
       months = { 'january' => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("All months must be an integer, received: #{months}")
+        expect(e.message).to eq("Month key must be an integer, received: 'january'")
       }
     end
 
     it 'returns error if months not 0 through 12' do
       months = { -1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("All months must be between 0 and 12, received: #{months}")
+        expect(e.message).to eq("Month key must be between 0 and 12, received: '-1'")
       }
 
       months = { 13 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("All months must be between 0 and 12, received: #{months}")
+        expect(e.message).to eq("Month key must be between 0 and 12, received: '13'")
       }
     end
 
     it 'returns error if month has no name' do
       months = { 1 => [{""=>"Test Holiday", "regions"=>["test"], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-        expect(e.message).to eq("All months must have a name, received: #{months}")
+        expect(e.message).to eq("A holiday in month 1 is missing a 'name', received: #{months[1].first}")
       }
     end
 
     it 'returns error if month has no regions' do
       months = { 1 => [{"name"=>"Test Holiday", "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidRegions) { |e|
-        expect(e.message).to eq("A month must contain at least one region, received: #{months}")
+        expect(e.message).to eq("Holiday 'Test Holiday' in month 1 must contain at least one region, received: nil")
       }
     end
 
     it 'returns error if month has empty regions' do
       months = { 1 => [{"name"=>"Test Holiday", "regions" => [], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidRegions) { |e|
-        expect(e.message).to eq("A month must contain at least one region, received: #{months}")
+        expect(e.message).to eq("Holiday 'Test Holiday' in month 1 must contain at least one region, received: []")
       }
     end
 
     it 'returns error if month has empty regions' do
       months = { 1 => [{"name"=>"Test Holiday", "regions"=>[""], "mday"=>1}] }
       expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidRegions) { |e|
-        expect(e.message).to eq("A month must contain at least one region, received: #{months}")
+        expect(e.message).to eq("Holiday 'Test Holiday' in month 1 contains an empty region, received: [\"\"]")
       }
     end
 
@@ -72,35 +72,35 @@ describe Definitions::Validation::Month do
       it 'returns error if year_ranges contains unknown subkey' do
         months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"blah" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-          expect(e.message).to eq("The :year_ranges value only accepts the following: :until, :from, :limited, :between, received: #{months}")
+          expect(e.message).to eq("Holiday 'Test Holiday' in month 1 has an invalid year_ranges selector 'blah'. Valid selectors are: until, from, limited, between")
         }
       end
 
       it 'returns error if :until value is not a single integer' do
         months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"until" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-          expect(e.message).to eq("The year_ranges.until value must contain a single 'year' integer, ex. 2018, received: #{months}")
+          expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.until must contain a single 'year' integer, ex. 2018, received: [2018]")
         }
       end
 
       it 'returns error if :from value is not a single integer' do
         months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"from" => [2018]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-          expect(e.message).to eq("The year_ranges.from value must contain a single 'year' integer, ex. 2018, received: #{months}")
+          expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.from must contain a single 'year' integer, ex. 2018, received: [2018]")
         }
       end
 
       it 'returns error if :limited value is not an array' do
         months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"limited" => 2018} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-          expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
+          expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.limited must contain an array of 'year' integers, ex. [2018], received: 2018")
         }
       end
 
       it 'returns error if :limited value is not an array of integers' do
         months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"limited" => ["blah"]} }] }
         expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-          expect(e.message).to eq("The year_ranges.limited value must contain an array of 'year' integers, ex. [2018], received: #{months}")
+          expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.limited must contain only 'year' integers, ex. [2018], received: 'blah'")
         }
       end
 
@@ -108,49 +108,49 @@ describe Definitions::Validation::Month do
         it 'returns error if not a hash' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => "2008..2012" } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between must contain both a 'start' and 'end' key, received: \"2008..2012\"")
           }
         end
 
         it 'returns error if start is missing' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"end" => 2018} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between must contain both a 'start' and 'end' key, received: #{{"end" => 2018}.inspect}")
           }
         end
 
         it 'returns error if end is missing' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("year_ranges.between must contain both a 'start' and 'end' key, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between must contain both a 'start' and 'end' key, received: #{{"start" => 2016}.inspect}")
           }
         end
 
         it 'returns an error if start value is not an integer' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => "2016", "end" => 2018} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("The year_ranges.between.start value must contain a single 'year' integer, ex. 2018, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between.start must contain a single 'year' integer, ex. 2018, received: \"2016\"")
           }
         end
 
         it 'returns an error if end value is not an integer' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => "2018"} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("The year_ranges.between.end value must contain a single 'year' integer, ex. 2018, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between.end must contain a single 'year' integer, ex. 2018, received: \"2018\"")
           }
         end
 
         it 'returns an error if end value is before start' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => 2015} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("The year_ranges.between.end value cannot be before the start value, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between.end cannot be before the start value, received start: 2016, end: 2015")
           }
         end
 
         it 'returns an error if the start and end values are the same' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"between" => {"start" => 2016, "end" => 2016} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("The year_ranges.between start and end values cannot be the same, received: #{months}")
+            expect(e.message).to eq("Holiday 'Test Holiday' in month 1 year_ranges.between start and end values cannot be the same, received: 2016")
           }
         end
       end
@@ -159,14 +159,14 @@ describe Definitions::Validation::Month do
         it 'returns an error if provided an array' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => [{"from" => 2019}, {"between" => {"start" => 2014, "end" => 2016} }] }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("year_ranges only supports a single selector at this time, received: #{months}")
+            expect(e.message).to include("Holiday 'Test Holiday' in month 1 year_ranges only supports a single selector at this time, received: [")
           }
         end
 
         it 'returns an error if there is more than 1 sub key' do
           months = { 1 => [{"name"=>"Test Holiday", "regions"=>["test"], "mday"=>1, "year_ranges" => {"from" => 2019, "between" => {"start" => 2014, "end" => 2016} } }] }
           expect { subject.call(months) }.to raise_error(Definitions::Errors::InvalidMonth) { |e|
-            expect(e.message).to eq("year_ranges only supports a single selector at this time, received: #{months}")
+            expect(e.message).to include("Holiday 'Test Holiday' in month 1 year_ranges only supports a single selector at this time, received: {")
           }
         end
       end

--- a/spec/validation/test_validator_spec.rb
+++ b/spec/validation/test_validator_spec.rb
@@ -144,7 +144,7 @@ describe Definitions::Validation::Test do
         it 'raises error if invalid date' do
           tests.first["given"]["date"] = "blah"
           expect { subject.call(tests) }.to raise_error(Definitions::Errors::InvalidTest) { |e|
-            expect(e.message).to include "Test must contain valid date"
+            expect(e.message).to include "Test must contain valid date, date value was: 'blah'"
           }
         end
       end


### PR DESCRIPTION
Addresses the rest of #124, following #357 which fixed the exit code. Rebased onto master now that #357 has merged, so this contains only the work described below.

Three changes.

**Every file is checked on every run.** `run.rb` collects failures instead of exiting on the first one, then prints a summary and the errors grouped by file, and exits 1 if anything failed. Files are now processed in sorted order so the output is deterministic. A file with unparsable YAML no longer stops the other 78 from being checked.

**Multiple errors are reported per file.** `Definition#call` now returns an array of errors rather than raising, collecting from each of the four sections (`months`, `region_names`, `methods`, `tests`). This is per-section granularity: the first problem within a section still ends that section. That covers the specific complaint in the issue that errors in `methods` or `tests` are only visible after fixing an earlier error and rerunning. Collecting every error within a single section would mean converting all 36 raise sites into a collector, which is a much larger change and is not attempted here.

Note that `region_names` validation is skipped when `months` fails, since its coverage check is derived from the regions listed in `months`. Non-validation exceptions are deliberately not swallowed, so a genuine bug still surfaces rather than being reported as a definition error.

**Messages name the offending value.** `month_validator.rb` interpolated the entire `months` hash into 20 messages; it now reports the specific key or value plus the holiday name and month for context. `custom_method_validator.rb` raised with no message at all for three different conditions; those are now three distinct messages naming the method. Also fixed an unterminated quote in the test validator's invalid-date message.

## Results

Before, using the `ar.yaml` scenario from the issue (month `8` changed to `xyz`), the entire output was a single 2397-byte line:

```
Failed on file '.../ar.yaml', error: All months must be an integer, received: {0 => [{"name" => "Viernes Santo", "regions" => ["ar"], ... [2300 more bytes]
```

After, with that same `ar.yaml` change plus `au.yaml` broken in two separate sections at once:

```
Found 79 definition YAML files to check! Starting validation checks ...
Validations complete!

Summary
---------
Total files checked: 79
Passed: 77
Failed: 2
Files containing validation errors: 'ar.yaml', 'au.yaml'

Error details by definition file:

----
File: ar.yaml
Total errors found: 1
Details:
  Month key must be an integer, received: 'xyz'
----
----
File: au.yaml
Total errors found: 2
Details:
  Custom method 'bad_method' has invalid arguments: 'nonsense'. Valid arguments are: date, year, month, day
  Test must contain valid date, date value was: 'not-a-date' - {"given" => {"date" => ["not-a-date"], "regions" => ["au"]}, "expect" => {"holiday" => true}}
----
```

Exit code is 1. A clean tree reports all 79 passing and exits 0.

## Testing

`make test` passes, 96 examples, 100% line coverage maintained. `make validate` passes on a clean tree.

Specs updated for the changed messages and return type, with new coverage for multi-section collection, for skipping `region_names` when `months` fails, and for not swallowing non-validation exceptions.

One portability note: `Hash#inspect` changed format in Ruby 3.4 (`{"a"=>1}` became `{"a" => 1}`), so the specs build their expected output by interpolating the value rather than hardcoding either rendering. Verified green on 3.3, 3.4, 4.0 and ruby-head.
