### PR TITLE
Fix es_ga Santiago Apóstol: 25 July, not 23

### DIFF
--- a/es.yaml
+++ b/es.yaml
@@ -111,9 +111,15 @@ months:
     regions: [es_ct, es_vc]
     mday: 24
   7:
+  # Santiago Apóstol (Día Nacional de Galicia) is 25 July, not 23:
+  # - Real Decreto 2001/1983, art. 45.1.d: "25 de julio, Santiago Apóstol"
+  #   https://www.boe.es/buscar/act.php?id=BOE-A-1983-20906
+  # - Decreto 46/2025 (DOG): "se opta por el 25 de julio, fiesta de Santiago
+  #   Apóstol, como Día Nacional de Galicia"
+  #   https://www.xunta.gal/dog/Publicados/2025/20250620/AnuncioG0767-120625-0002_es.html
   - name: Santiago Apostol
     regions: [es_ga]
-    mday: 23
+    mday: 25
     observed: to_monday_if_sunday(date)
   8:
   - name: Asunción
@@ -485,7 +491,7 @@ tests:
     expect:
       name: "Día de La Rioja"
   - given:
-      date: '2009-07-23'
+      date: '2009-07-25'
       regions: ["es_ga"]
     expect:
       name: "Santiago Apostol"


### PR DESCRIPTION
## What

Fixes the date of `Santiago Apostol` (`es_ga`, Galicia): it falls on **25 July**, not 23 July. Also fixes the test that asserted the wrong date (`2009-07-23` → `2009-07-25`).

## Why

Santiago Apóstol / Día Nacional de Galicia is 25 July:

- Real Decreto 2001/1983, art. 45.1.d (consolidated, in force): *"19 de marzo, San José, o **25 de julio, Santiago Apóstol**"* — https://www.boe.es/buscar/act.php?id=BOE-A-1983-20906
- Decreto 46/2025 (Diario Oficial de Galicia), establishing Galicia's 2026 labor calendar: *"se opta por el **25 de julio**, fiesta de Santiago Apóstol, como Día Nacional de Galicia"* — https://www.xunta.gal/dog/Publicados/2025/20250620/AnuncioG0767-120625-0002_es.html

The 23rd appears to have never been correct: the official BOE fiestas laborales tables from the era of this file's last update (2008-11-29) all list 25 July — [2006](https://www.boe.es/buscar/doc.php?id=BOE-A-2005-17217), [2007](https://www.boe.es/buscar/doc.php?id=BOE-A-2006-19349), [2008](https://www.boe.es/buscar/doc.php?id=BOE-A-2007-18306) and [2009](https://www.boe.es/buscar/doc.php?id=BOE-A-2008-18411) — so the previous test date of 2009-07-23 contradicted the official 2009 calendar as well.

`make validate` passes (79/79 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)