### PR TITLE
Update Peru holidays to the official calendar, dated from each law's first observance

### DIFF
--- a/pe.yaml
+++ b/pe.yaml
@@ -9,6 +9,10 @@
 # - https://www.gob.pe/feriados
 # - https://www.gob.pe/feriados/historicos
 #
+# Two entries that were never feriados are marked informal: 6 January
+# (Bajada de Reyes) and Domingo de Resurrección. With those corrected the
+# formal list matches the official 16 exactly.
+#
 # Peru added four national holidays between 2021 and 2023. Each is dated from
 # its first observance, which is not always the year the law was published:
 #
@@ -44,17 +48,22 @@ months:
     regions: [pe]
     function: easter(year)
     function_modifier: -2
+  # Domingo de Resurrección is widely observed but is not a feriado; only
+  # Jueves Santo and Viernes Santo are days off under DL 713.
   - name: Pascua
     regions: [pe]
     function: easter(year)
+    type: informal
   1:
   - name: Año Nuevo
     regions: [pe]
     mday: 1
+  # Bajada de Reyes is celebrated locally but is an ordinary working day, so it
+  # carries no statutory observance rule.
   - name: Día de los Reyes Magos
     regions: [pe]
     mday: 6
-    observed: to_monday_if_sunday(date)
+    type: informal
   5:
   - name: Día del Trabajador
     regions: [pe]
@@ -304,3 +313,27 @@ tests:
       regions: ["pe"]
     expect:
       name: "Batalla de Ayacucho"
+  # Never feriados, so informal only. DL 713 makes Jueves Santo and Viernes
+  # Santo days off but not Domingo de Resurrección.
+  - given:
+      date: ['2016-01-06', '2026-01-06']
+      regions: ["pe"]
+    expect:
+      holiday: false
+  - given:
+      date: '2026-01-06'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      name: "Día de los Reyes Magos"
+  - given:
+      date: ['2016-03-27', '2026-04-05']
+      regions: ["pe"]
+    expect:
+      holiday: false
+  - given:
+      date: '2026-04-05'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      name: "Pascua"

--- a/pe.yaml
+++ b/pe.yaml
@@ -1,11 +1,25 @@
 # Peruvian holiday definitions for the Ruby Holiday gem.
 #
 # created: 2016-06-18.
-# updated: 2016-06-18.
+# updated: 2026-08-12.
 #
 # Sources:
 # - http://www.timeanddate.com/holidays/peru/
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Peru
+# - https://www.gob.pe/feriados
+# - https://www.gob.pe/feriados/historicos
+#
+# Peru added four national holidays between 2021 and 2023. Each is dated from
+# its first observance, which is not always the year the law was published:
+#
+#   9 December  Batalla de Ayacucho     Ley 31381, published 2021-12-31, from 2022
+#   6 August    Batalla de Junín        Ley 31530, published 2022-07-26, from 2022
+#   7 June      Batalla de Arica        Ley 31788, published 2023-06-15, from 2024
+#  23 July      Día de la Fuerza Aérea  Ley 31822, published 2023-07-08, from 2023
+#
+# Ley 31530 was published before 6 August 2022, so that holiday was observed
+# the same year; Ley 31788 was published after 7 June 2023, so the first
+# observance was 2024.
 #
 # Avoided days:
 #   March equinox
@@ -51,10 +65,18 @@ months:
     wday: 0
     type: informal
   6:
+  # An informal observance until Ley 31788 made it a paid national holiday.
   - name: Día de la Bandera
     regions: [pe]
     mday: 7
     type: informal
+    year_ranges:
+      until: 2023
+  - name: Batalla de Arica y Día de la Bandera
+    regions: [pe]
+    mday: 7
+    year_ranges:
+      from: 2024
   - name: Día del Padre
     regions: [pe]
     week: 3
@@ -64,10 +86,15 @@ months:
     regions: [pe]
     mday: 24
     type: informal
-  - name: San Pablo y San Pedro
+  - name: Día de San Pedro y San Pablo
     regions: [pe]
     mday: 29
   7:
+  - name: Día de la Fuerza Aérea del Perú
+    regions: [pe]
+    mday: 23
+    year_ranges:
+      from: 2023
   - name: Primer Día de la Independencia
     regions: [pe]
     mday: 28
@@ -75,6 +102,11 @@ months:
     regions: [pe]
     mday: 29
   8:
+  - name: Batalla de Junín
+    regions: [pe]
+    mday: 6
+    year_ranges:
+      from: 2022
   - name: Santa Rosa de Lima
     regions: [pe]
     mday: 30
@@ -84,7 +116,7 @@ months:
     mday: 24
     type: informal
   10:
-  - name: Batalla de Angamos
+  - name: Combate de Angamos
     regions: [pe]
     mday: 8
   11:
@@ -96,6 +128,11 @@ months:
     regions: [pe]
     mday: 8
     observed: to_monday_if_sunday(date)
+  - name: Batalla de Ayacucho
+    regions: [pe]
+    mday: 9
+    year_ranges:
+      from: 2022
   - name: Navidad del Señor
     regions: [pe]
     mday: 25
@@ -160,7 +197,7 @@ tests:
       regions: ["pe"]
       options: ["informal"]
     expect:
-      name: "San Pablo y San Pedro"
+      name: "Día de San Pedro y San Pablo"
   - given:
       date: '2016-07-28'
       regions: ["pe"]
@@ -190,7 +227,7 @@ tests:
       regions: ["pe"]
       options: ["informal"]
     expect:
-      name: "Batalla de Angamos"
+      name: "Combate de Angamos"
   - given:
       date: '2016-11-01'
       regions: ["pe"]
@@ -209,3 +246,61 @@ tests:
       options: ["informal"]
     expect:
       name: "Navidad del Señor"
+  #
+  # Holidays added by Ley 31381, 31530, 31788 and 31822, each checked either
+  # side of its first observance. Cases without the informal option assert
+  # that the date is a full national holiday.
+  #
+  # 7 June: informal through 2023, national holiday from 2024
+  - given:
+      date: '2023-06-07'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      name: "Día de la Bandera"
+  - given:
+      date: '2023-06-07'
+      regions: ["pe"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2024-06-07', '2026-06-07']
+      regions: ["pe"]
+    expect:
+      name: "Batalla de Arica y Día de la Bandera"
+  # 23 July: national holiday from 2023
+  - given:
+      date: '2022-07-23'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2023-07-23', '2026-07-23']
+      regions: ["pe"]
+    expect:
+      name: "Día de la Fuerza Aérea del Perú"
+  # 6 August: national holiday from 2022
+  - given:
+      date: '2021-08-06'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2022-08-06', '2026-08-06']
+      regions: ["pe"]
+    expect:
+      name: "Batalla de Junín"
+  # 9 December: national holiday from 2022
+  - given:
+      date: '2021-12-09'
+      regions: ["pe"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2022-12-09', '2026-12-09']
+      regions: ["pe"]
+    expect:
+      name: "Batalla de Ayacucho"


### PR DESCRIPTION
Takes over #353 by @juniorUsca, whose research against gob.pe this is built on. Reworked to date each change from the year it actually took effect, and to keep the existing tests asserting historical truth.

Peru added four national holidays between 2021 and 2023. The first observance is not always the publication year, so each gets its own `year_ranges`:

| Holiday | Law | Published | From |
|---|---|---|---|
| 9 Dec Batalla de Ayacucho | 31381 | 2021-12-31 | 2022 |
| 6 Aug Batalla de Junín | 31530 | 2022-07-26 | 2022 |
| 7 Jun Batalla de Arica y Día de la Bandera | 31788 | 2023-06-15 | 2024 |
| 23 Jul Día de la Fuerza Aérea del Perú | 31822 | 2023-07-08 | 2023 |

Ley 31530 was published before 6 August 2022 so it applied that year, while Ley 31788 was published after 7 June 2023 so the first observance was 2024. Dating them all from publication would have been wrong in both directions.

7 June is split rather than replaced: informal `until: 2023`, then the national holiday `from: 2024`.

Two name corrections apply to every year, since the old names were simply wrong: `San Pablo y San Pedro` to `Día de San Pedro y San Pablo`, and `Batalla de Angamos` to `Combate de Angamos`.

Changes from #353:

- Adds `year_ranges` throughout. #353 applied everything unconditionally, which would have made `Holidays.on(Date.civil(2016,12,9), [:pe])` return a holiday that did not exist, and changed the 2016 test for 7 June to assert a name coined in 2023.
- Adds 6 August Batalla de Junín, which #353 missed and which is on the official list.
- Keeps 24 September Día de las Fuerzas Armadas as informal. #353 deleted it; it is a real commemorative day, just not a feriado.
- Adds tests either side of every boundary year, and cases without the informal option to prove the new dates are full national holidays.

Verified against the gem: formal holiday counts climb as each law takes effect, 12 in 2021, 14 in 2022, 15 in 2023 and 16 from 2024. Full gem suite passes at 500 tests, 9460 assertions.

Second commit fixes a longstanding bug this work surfaced. `pe.yaml` counted 18 formal holidays against Peru's official 16, because `Día de los Reyes Magos` and `Pascua` have been marked formal since the file was created in 2016. Neither is a feriado: DL 713 makes Jueves Santo and Viernes Santo days off but not Domingo de Resurrección, and 6 January is an ordinary working day. Both are now `informal`, so they stay available to callers who ask for informal holidays but no longer count as days off. `Día de los Reyes Magos` also loses its `observed: to_monday_if_sunday(date)` rule, which only makes sense for a statutory holiday.

With that corrected, 2026 returns exactly the official 16, matching gob.pe item for item.
