### PR TITLE
Fix es_ga Santiago Apóstol date to 25 July

### DIFF
--- a/es.yaml
+++ b/es.yaml
@@ -111,9 +111,15 @@ months:
     regions: [es_ct, es_vc]
     mday: 24
   7:
+  # Santiago Apóstol (Día Nacional de Galicia) is 25 July, not 23:
+  # - Real Decreto 2001/1983, art. 45.1.d: "25 de julio, Santiago Apóstol"
+  #   https://www.boe.es/buscar/act.php?id=BOE-A-1983-20906
+  # - Decreto 46/2025 (DOG): "se opta por el 25 de julio, fiesta de Santiago
+  #   Apóstol, como Día Nacional de Galicia"
+  #   https://www.xunta.gal/dog/Publicados/2025/20250620/AnuncioG0767-120625-0002_es.html
   - name: Santiago Apostol
     regions: [es_ga]
-    mday: 23
+    mday: 25
     observed: to_monday_if_sunday(date)
   8:
   - name: Asunción
@@ -485,10 +491,28 @@ tests:
     expect:
       name: "Día de La Rioja"
   - given:
-      date: '2009-07-23'
+      date: '2009-07-25'
       regions: ["es_ga"]
     expect:
       name: "Santiago Apostol"
+  # 25 July falls on a Sunday in 2021 and 2027, which is the only case the
+  # observed rule does anything with.
+  - given:
+      date: ['2021-07-25', '2027-07-25']
+      regions: ["es_ga"]
+    expect:
+      name: "Santiago Apostol"
+  - given:
+      date: ['2021-07-26', '2027-07-26']
+      regions: ["es_ga"]
+      options: ["observed"]
+    expect:
+      name: "Santiago Apostol"
+  - given:
+      date: '2021-07-23'
+      regions: ["es_ga"]
+    expect:
+      holiday: false
   - given:
       date: '2009-09-02'
       regions: ["es_ce"]


### PR DESCRIPTION
Takes over #361 by @trumbitta, whose research and sources this is built on.

`Santiago Apostol` (`es_ga`, Galicia) was defined as 23 July. It's 25 July, St James' Day:

- Real Decreto 2001/1983, art. 45.1.d: "25 de julio, Santiago Apóstol" ([BOE](https://www.boe.es/buscar/act.php?id=BOE-A-1983-20906))
- Decreto 46/2025 (DOG), Galicia's 2026 labour calendar: "se opta por el 25 de julio, fiesta de Santiago Apóstol, como Día Nacional de Galicia" ([DOG](https://www.xunta.gal/dog/Publicados/2025/20250620/AnuncioG0767-120625-0002_es.html))

As @trumbitta noted, 23 July appears never to have been right. The BOE fiestas laborales tables from the era of this file's last update all list 25 July, so the old `2009-07-23` test contradicted the official 2009 calendar it was supposedly asserting.

Added on top of #361: coverage for the `observed: to_monday_if_sunday(date)` rule, which had none. 25 July falls on a Sunday in 2021 and 2027, the only case where that rule does anything, so both years are now tested on the day itself and on the observed Monday. There's also a negative test on 23 July to pin down that the old date is gone.

Verified against the gem, before and after:

| Year | 25 Jul | 23 Jul | 26 Jul with `:observed` |
|---|---|---|---|
| 2009 (Sat) | Santiago Apostol | none | none |
| 2021 (Sun) | Santiago Apostol | none | Santiago Apostol |
| 2026 (Sat) | Santiago Apostol | none | none |
| 2027 (Sun) | Santiago Apostol | none | Santiago Apostol |

Full gem suite passes at 500 tests, 9432 assertions.

This changes an existing date, so it wants a CHANGELOG entry in the next release.
