### PR TITLE
Fix jp substitute holidays ignoring year_ranges when scanning forward

### DIFF
--- a/jp.yaml
+++ b/jp.yaml
@@ -367,7 +367,9 @@ methods:
       # This suuuucks. I have no idea how to make this not reach into our interal ruby API to do this.
       # I'm punting, I'll come back to this.
       is_holiday = Holidays::JP.holidays_by_month[date.month].any? do |holiday|
-        holiday[:mday] == date.day
+        next false unless holiday[:mday] == date.day
+        next true unless holiday[:year_ranges]
+        Holidays::Finder::Rules::YearRange.call(date.year, holiday[:year_ranges])
       end
       date.wday == 0 || is_holiday ? (Holidays::Factory::Definition.custom_methods_repository.find("jp_next_weekday(date)").call(date+1)) : date
 
@@ -482,6 +484,30 @@ tests:
       name: "振替休日"
   - given:
       date: '2019-08-12'
+      regions: ["jp"]
+      options: ["informal"]
+    expect:
+      name: "振替休日"
+  - given:
+      date: '2018-04-30'
+      regions: ["jp"]
+      options: ["informal"]
+    expect:
+      name: "振替休日"
+  - given:
+      date: '2018-05-07'
+      regions: ["jp"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: '2019-04-30'
+      regions: ["jp"]
+      options: ["informal"]
+    expect:
+      name: "休日"
+  - given:
+      date: '2019-05-06'
       regions: ["jp"]
       options: ["informal"]
     expect:


### PR DESCRIPTION
`jp_next_weekday` matched candidate dates on `mday` alone, so the 2019-only Reiwa accession entries (30 April, 1 May, 2 May) counted as holidays in every year. In 2018, 昭和の日 fell on Sunday 29 April, and the substitute walk skipped those three dates plus 3/4/5 May and landed on Monday 7 May. That is both halves of holidays#366: the missing 30 April substitute and the spurious 7 May holiday. The Saturday theory in the issue is not the cause.

The scan now checks `year_ranges` via `Holidays::Finder::Rules::YearRange`. Adds regression tests for 2018-04-30, 2018-05-07 and for 2019-04-30 / 2019-05-06 to pin Golden Week 2019.

Fixes https://github.com/holidays/holidays/issues/366
