### PR TITLE
Fix kr Seollal eve resolving to the wrong year

### DIFF
--- a/kr.yaml
+++ b/kr.yaml
@@ -13,6 +13,9 @@ region_names:
   kr: "South Korea"
 months:
   1:
+  - name: 설날 연휴
+    regions: [kr]
+    function: kr_seollal_eve(year, region)
   - name: 설날
     regions: [kr]
     function: lunar_to_solar(year, month, day, region)
@@ -73,10 +76,12 @@ months:
   - name: 크리스마스
     regions: [kr]
     mday: 25
-  - name: 설날 연휴
-    regions: [kr]
-    function: lunar_to_solar(year, month, day, region)
-    mday: 30
+
+methods:
+  kr_seollal_eve:
+    arguments: year, region
+    ruby: |
+      Holidays::Factory::Definition.custom_methods_repository.find("lunar_to_solar(year, month, day, region)").call(year, 1, 1, region) - 1
 
 tests:
   - given:
@@ -157,6 +162,36 @@ tests:
       options: ["informal"]
     expect:
       name: "설날"
+  - given:
+      date: '2017-01-27'
+      regions: ["kr"]
+      options: ["informal"]
+    expect:
+      name: "설날 연휴"
+  - given:
+      date: '2017-02-15'
+      regions: ["kr"]
+      options: ["informal"]
+    expect:
+      holiday: false
+  - given:
+      date: '2020-01-24'
+      regions: ["kr"]
+      options: ["informal"]
+    expect:
+      name: "설날 연휴"
+  - given:
+      date: '2022-01-31'
+      regions: ["kr"]
+      options: ["informal"]
+    expect:
+      name: "설날 연휴"
+  - given:
+      date: '2025-01-28'
+      regions: ["kr"]
+      options: ["informal"]
+    expect:
+      name: "설날 연휴"
 
 # These are commented out until I can have a discussion and better understand these holidays.
 # Please see [issue 69](https://github.com/holidays/definitions/issues/69) (nice) for more information.


### PR DESCRIPTION
Fixes holidays/holidays#388.

`설날 연휴` (Seollal eve) was defined under month 12 as
`lunar_to_solar(year, 12, 30, region)`. Three things go wrong with that:

* it uses the same lunar year rather than the previous one
* the gem forces the result back into the searched year at `search.rb:98`
  (`Date.civil(year, result.month, result.mday)`)
* lunar 12/30 does not exist in every lunar year, 2015 ended on 12/29

For 2017 that produced a spurious `설날 연휴` on 2017-02-15 while the real
eve dates returned nothing, and 2025 loses the eve entirely. It is live in
released gem 11.4.0.

This derives the eve as Seollal minus one day instead, via a new
`kr_seollal_eve(year, region)` method under month 1. Seollal always falls
between 21 Jan and 20 Feb, so the eve never crosses a Gregorian year
boundary and the year-forcing never applies. No gem change needed.

Tests cover 2017, 2020, 2022 and 2025, plus a negative case asserting
2017-02-15 is no longer a holiday.

The gem-side year-forcing is still a real latent defect, but kr's
`설날 연휴` was the only definition in the repo exercising the cross-year
path (checked every `function:` under months 1 and 12), so after this it
has no remaining consumer. Worth a separate gem issue, not a blocker here.

This does not address the other two bugs discussed in #69 (the `on` vs
`between` inconsistency for 추석, which is a separate gem bug, and 대체휴일
substitute holidays).
