### PR TITLE
Add de_mv Internationaler Frauentag start year boundary test

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -442,6 +442,11 @@ tests:
     expect:
       name: "Internationaler Frauentag"
   - given:
+      date: '2022-03-08'
+      regions: ["de_mv"]
+    expect:
+      holiday: false
+  - given:
       date: '2023-03-08'
       regions: ["de_mv"]
     expect:


### PR DESCRIPTION
Follow-up to #245, which added `Internationaler Frauentag` for
Mecklenburg-Vorpommern from 2023 and resolved #240.

de_be has a negative test for 2018, the year before Berlin's start
year, but there was no equivalent for de_mv. The `from: 2023` boundary
was only pinned on the positive side, so a regression that widened the
range would not have been caught.

Verified against the current definitions:

    2022 de_mv: []
    2023 de_mv: ["Internationaler Frauentag"]

No definition change, test only.
