### PR TITLE
Restrict ro Boboteaza and Sfantul Ioan to 2024 onwards

### DIFF
--- a/ro.yaml
+++ b/ro.yaml
@@ -22,6 +22,16 @@
 # Sources:
 # - https://www.avocatnet.ro/articol_68582/Zile-libere-2025-Cate-dintre-liberele-legale-de-anul-viitor-vor-pica-in-timpul-s%C4%83pt%C4%83manii.html
 # - https://www.mediafax.ro/social/calendarul-sarbatorilor-legale-2025-de-cate-zile-libere-se-bucura-angajatii-din-romania-iata-cand-sunt-urmatoarele-zile-libere-pentru-romani-22630313
+#
+# Changes 2026-08-20
+# - Restrict Botezul Domnului - Boboteaza and Soborul Sfântului Proroc Ioan
+#   Botezătorul to 2024 onwards. Legea nr. 52/2023 added 6 and 7 January to
+#   art. 139 of the Codul muncii, in force on publication but applied from
+#   2024, so neither was a sărbătoare legală before then.
+#
+# Sources:
+# - https://www.euronews.ro/articole/proiect-de-lege-6-si-7-ianuarie-zile-libere-sarbatoare-legala-nelucratoare
+# - https://www.avocatnet.ro/articol_62414/E-oficial-Salaria%C8%9Bii-vor-beneficia-de-zile-libere-in-6-%C8%99i-7-ianuarie.html
 ---
 region_names:
   ro: "Romania"
@@ -58,9 +68,13 @@ months:
   - name: Botezul Domnului - Boboteaza
     regions: [ro]
     mday: 6
+    year_ranges:
+      from: 2024
   - name: Soborul Sfântului Proroc Ioan Botezătorul
     regions: [ro]
     mday: 7
+    year_ranges:
+      from: 2024
   - name: Unirea Principatelor Române
     regions: [ro]
     mday: 24
@@ -254,6 +268,28 @@ tests:
       regions: ["ro"]
     expect:
       holiday: false
+  - given:
+      date: '2023-01-06'
+      regions: ["ro"]
+    expect:
+      holiday: false
+  - given:
+      date: '2023-01-07'
+      regions: ["ro"]
+    expect:
+      holiday: false
+  - given:
+      date: '2024-01-06'
+      regions: ["ro"]
+      options: ["informal"]
+    expect:
+      name: "Botezul Domnului - Boboteaza"
+  - given:
+      date: '2024-01-07'
+      regions: ["ro"]
+      options: ["informal"]
+    expect:
+      name: "Soborul Sfântului Proroc Ioan Botezătorul"
   - given:
       date: '2025-01-06'
       regions: ["ro"]


### PR DESCRIPTION
See #296.

`Botezul Domnului - Boboteaza` (6 January) and `Soborul Sfântului Proroc
Ioan Botezătorul` (7 January) were added in January 2025 but without a
`year_ranges`, so they currently return a holiday for every year in
history:

    2019-01-06: ["Botezul Domnului - Boboteaza"]
    2023-01-06: ["Botezul Domnului - Boboteaza"]
    2024-01-06: ["Botezul Domnului - Boboteaza"]

Only the last of those is right. Legea nr. 52/2023 added both days to
art. 139 of the Codul muncii. It entered into force on publication in
2023 but applies from 2024, so neither was a sărbătoare legală before
then.

Adds `from: 2024` to both, with negative tests for 2023 and positive
tests for 2024 to pin the boundary on each side. The existing 2025 tests
are unchanged.

Note this is not quite what #296 asked for. The reporter said the two
days were missing entirely, which was true when they filed in January
2025 and was fixed shortly after. The remaining defect is the missing
year range.
