### PR TITLE
Add Day of the Dead as informal us/ca holiday

### DIFF
--- a/northamericainformal.yaml
+++ b/northamericainformal.yaml
@@ -51,6 +51,16 @@ months:
     mday: 31
     type: informal
 
+  11:
+  - name: Day of the Dead
+    regions: [us, ca]
+    mday: 1
+    type: informal
+  - name: Day of the Dead
+    regions: [us, ca]
+    mday: 2
+    type: informal
+
 tests:
   - given:
       date: '2013-02-02'
@@ -106,3 +116,15 @@ tests:
       options: ["informal"]
     expect:
       name: "Halloween"
+  - given:
+      date: '2013-11-01'
+      regions: ["us"]
+      options: ["informal"]
+    expect:
+      name: "Day of the Dead"
+  - given:
+      date: '2013-11-02'
+      regions: ["us"]
+      options: ["informal"]
+    expect:
+      name: "Day of the Dead"


### PR DESCRIPTION
Adds Día de los Muertos / Day of the Dead as an informal holiday for `us` and `ca`, on November 1 and 2, in `northamericainformal.yaml`.

This follows the existing pattern in that file (Halloween, Groundhog Day, Valentine's Day, etc. are all informal us/ca observances) and mirrors `mx.yaml`, which already has the Mexican equivalents (Todos los Santos, Los Fieles Difuntos) as informal entries on the same two days.

Closes holidays/holidays#393