### PR TITLE
Fix nz_sl Southland and nz_hb Hawke's Bay anniversary dates

### DIFF
--- a/nz.yaml
+++ b/nz.yaml
@@ -32,6 +32,10 @@ months:
   - name: Matariki
     regions: [nz]
     function: matariki(year)
+  - name: Southland Anniversary Day
+    regions: [nz_sl]
+    function: easter(year)
+    function_modifier: 2
   1:
   - name: New Year's Day
     regions: [nz]
@@ -41,9 +45,6 @@ months:
     regions: [nz]
     mday: 2
     observed: to_weekday_if_boxing_weekend(date)
-  - name: Southland Anniversary Day
-    regions: [nz_sl]
-    mday: 17
   - name: Wellington Anniversary Day
     regions: [nz_we]
     mday: 22
@@ -101,7 +102,7 @@ months:
   10:
   - name: Hawke's bay Anniversary Day
     regions: [nz_hb]
-    week: 1
+    week: 4
     wday: 1
     observed: previous_friday(date)
   - name: Labour Day
@@ -136,6 +137,28 @@ months:
     observed: to_weekday_if_boxing_weekend(date)
 
 tests:
+  - given:
+      date: '2024-04-02'
+      regions: ["nz_sl"]
+    expect:
+      name: "Southland Anniversary Day"
+  - given:
+      date: '2025-04-22'
+      regions: ["nz_sl"]
+    expect:
+      name: "Southland Anniversary Day"
+  - given:
+      date: '2024-10-25'
+      regions: ["nz_hb"]
+      options: ["observed"]
+    expect:
+      name: "Hawke's bay Anniversary Day"
+  - given:
+      date: '2025-10-24'
+      regions: ["nz_hb"]
+      options: ["observed"]
+    expect:
+      name: "Hawke's bay Anniversary Day"
   - given:
       date: '2007-01-01'
       regions: ["nz"]


### PR DESCRIPTION
Fixes two of the three date rules reported in #260 (Canterbury was already fixed).

- `nz_sl` Southland Anniversary Day was a fixed 17 January with no observed rule. It's actually observed on Easter Tuesday (Easter Sunday + 2 days), per the government holidays page linked in the issue. Changed to `function: easter(year)`, `function_modifier: 2`, matching how Good Friday and Easter Monday are already handled in this file.
- `nz_hb` Hawke's Bay Anniversary Day used `week: 1` (first Monday of October) with `previous_friday`, i.e. the Friday before the first Monday. The correct rule is the Friday before Labour Day, which is the fourth Monday of October. Changed `week: 1` to `week: 4`.

Added tests for both across 2024/2025. Verified against the real gem generator: cloned `holidays/holidays`, swapped in this branch as `definitions/`, ran `make generate && make test-contract` — 101 tests, 8316 assertions, 0 failures.

Closes #260.