### PR TITLE
Extend tr Ramazan and Kurban Bayramı dates through 2026

### DIFF
--- a/tr.yaml
+++ b/tr.yaml
@@ -1,10 +1,13 @@
 # Turkish holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2019-02-10
+# Updated: 2026-08-25
 #
 # Note:
 # This holiday definition file contains pre-defined dates
-# for Ramadan Feast and Sacrifice Feast from 2014 to 2019.
+# for Ramadan Feast and Sacrifice Feast from 2014 to 2026. These are
+# calendar-proclaimed dates (Diyanet), not derived algorithmically, so the
+# table needs extending periodically. See definitions#55 for the longer-term
+# plan to calculate these dynamically instead.
 #
 # Sources:
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Turkey
@@ -15,6 +18,7 @@
 # - https://translate.yandex.com/?lang=en-tr
 # - https://de.wikibooks.org/wiki/Türkisch:_Zahlen
 # - https://en.wikipedia.org/wiki/Democracy_and_National_Unity_Day
+# - https://vakithesaplama.diyanet.gov.tr/resmitatiller.php (2021-2026 dates)
 ---
 region_names:
   tr: "Türkiye"
@@ -87,7 +91,13 @@ methods:
           '2017' => Date.civil(2017, 6, 25),
           '2018' => Date.civil(2018, 6, 15),
           '2019' => Date.civil(2019, 6, 4),
-          '2020' => Date.civil(2020, 5, 24)
+          '2020' => Date.civil(2020, 5, 24),
+          '2021' => Date.civil(2021, 5, 13),
+          '2022' => Date.civil(2022, 5, 2),
+          '2023' => Date.civil(2023, 4, 21),
+          '2024' => Date.civil(2024, 4, 10),
+          '2025' => Date.civil(2025, 3, 30),
+          '2026' => Date.civil(2026, 3, 20)
       }
       begin_of_ramadan_feast[year.to_s]
   sacrifice_feast:
@@ -100,7 +110,13 @@ methods:
           '2017' => Date.civil(2017, 9, 1),
           '2018' => Date.civil(2018, 8, 21),
           '2019' => Date.civil(2019, 8, 11),
-          '2020' => Date.civil(2020, 7, 31)
+          '2020' => Date.civil(2020, 7, 31),
+          '2021' => Date.civil(2021, 7, 20),
+          '2022' => Date.civil(2022, 7, 9),
+          '2023' => Date.civil(2023, 6, 28),
+          '2024' => Date.civil(2024, 6, 16),
+          '2025' => Date.civil(2025, 6, 6),
+          '2026' => Date.civil(2026, 5, 27)
       }
       begin_of_sacrifice_feast[year.to_s]
 tests:
@@ -135,17 +151,17 @@ tests:
     expect:
       name: "Cumhuriyet Bayramı"
   - given:
-      date: ['2017-6-25', '2018-6-15', '2019-6-4', '2020-5-24']
+      date: ['2017-6-25', '2018-6-15', '2019-6-4', '2020-5-24', '2021-5-13', '2022-5-2', '2023-4-21', '2024-4-10', '2025-3-30', '2026-3-20']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı"
   - given:
-      date: ['2017-6-26', '2018-6-16', '2019-6-5', '2020-5-25']
+      date: ['2017-6-26', '2018-6-16', '2019-6-5', '2020-5-25', '2021-5-14', '2022-5-3', '2023-4-22', '2024-4-11', '2025-3-31', '2026-3-21']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-6-27', '2018-6-17', '2019-6-6', '2020-5-26']
+      date: ['2017-6-27', '2018-6-17', '2019-6-6', '2020-5-26', '2021-5-15', '2022-5-4', '2023-4-23', '2024-4-12', '2025-4-1', '2026-3-22']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (üçüncü tatil)"
@@ -155,22 +171,22 @@ tests:
     expect:
       name: "Demokrasi ve Milli Birlik Günü"
   - given:
-      date: ['2017-9-1', '2018-8-21', '2019-8-11', '2020-7-31']
+      date: ['2017-9-1', '2018-8-21', '2019-8-11', '2020-7-31', '2021-7-20', '2022-7-9', '2023-6-28', '2024-6-16', '2025-6-6', '2026-5-27']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı"
   - given:
-      date: ['2017-9-2', '2018-8-22', '2019-8-12', '2020-8-01']
+      date: ['2017-9-2', '2018-8-22', '2019-8-12', '2020-8-01', '2021-7-21', '2022-7-10', '2023-6-29', '2024-6-17', '2025-6-7', '2026-5-28']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-9-3', '2018-8-23', '2019-8-13', '2020-8-02']
+      date: ['2017-9-3', '2018-8-23', '2019-8-13', '2020-8-02', '2021-7-22', '2022-7-11', '2023-6-30', '2024-6-18', '2025-6-8', '2026-5-29']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (üçüncü tatil)"
   - given:
-      date: ['2017-9-4', '2018-8-24', '2019-8-14', '2020-8-03']
+      date: ['2017-9-4', '2018-8-24', '2019-8-14', '2020-8-03', '2021-7-23', '2022-7-12', '2023-7-1', '2024-6-19', '2025-6-9', '2026-5-30']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (dördüncü tatil)"


### PR DESCRIPTION
The Ramazan Bayramı (Ramadan/Eid al-Fitr) and Kurban Bayramı (Sacrifice/Eid al-Adha) dates in `tr.yaml` are a hand-maintained lookup table, since Diyanet's calendar-proclaimed dates aren't purely algorithmic (see #55 for the longer discussion on that). The table stopped at 2020, so for every year since 2021 both holidays (7 holiday-days total per year) have silently dropped out of the `tr` region entirely.

Extended the table through 2026 using Diyanet's published official holiday calendar:

- Ramazan Bayramı: 2021-05-13, 2022-05-02, 2023-04-21, 2024-04-10, 2025-03-30, 2026-03-20
- Kurban Bayramı: 2021-07-20, 2022-07-09, 2023-06-28, 2024-06-16, 2025-06-06, 2026-05-27

Added test cases for all six new years across both feasts and their 2nd/3rd/4th holiday days. Verified against the real gem generator: cloned `holidays/holidays`, swapped in this branch as `definitions/`, ran `make generate && make test-contract` — 101 tests, 8366 assertions, 0 failures.

This is a stopgap. #55 discusses actually calculating these dynamically instead of maintaining a table that needs periodic extension; I'll open a follow-up issue scoping that separately.