### PR TITLE
Fix typo in th.yaml test date: 20019-01-01 -> 2019-01-01

### DIFF
--- a/th.yaml
+++ b/th.yaml
@@ -52,7 +52,7 @@ months:
 
 tests:
   - given:
-      date: '20019-01-01'
+      date: '2019-01-01'
       regions: ["th"]
       options: ["informal"]
     expect:


### PR DESCRIPTION
Fixes #380. th.yaml's first test case had `date: '20019-01-01'` (5-digit year) instead of `2019-01-01`, so downstream test generators either test a nonsense year or silently drop the case.

Validation passes (`make validate`, 81/81).