### PR TITLE
Switch tr Ramazan and Kurban Bayramı to a calculated Hijri date

### DIFF
--- a/tr.yaml
+++ b/tr.yaml
@@ -3,11 +3,17 @@
 # Updated: 2026-08-25
 #
 # Note:
-# This holiday definition file contains pre-defined dates
-# for Ramadan Feast and Sacrifice Feast from 2014 to 2030. These are
-# calendar-proclaimed dates (Diyanet), not derived algorithmically, so the
-# table needs extending periodically. See definitions#55 and definitions#377
-# for the longer-term plan to calculate these dynamically instead.
+# Ramazan Bayramı and Kurban Bayramı fall on fixed days of the Hijri
+# calendar (1 Shawwal and 10 Dhul-Hijjah respectively). The ramadan_feast
+# and sacrifice_feast custom methods compute them from a tabular Islamic
+# calendar calculation in the consuming libraries, with a per-year override
+# for the years where Türkiye's Diyanet proclamation differs from the
+# arithmetic. See definitions#377 and definitions#55.
+#
+# Roughly once every 33 years a fixed Hijri date lands twice in the same
+# Gregorian year (e.g. Ramazan Bayramı in 2033, Kurban Bayramı in 2039); the
+# function returns only the first occurrence, so tests here stop before the
+# first such year.
 #
 # Sources:
 # - https://en.wikipedia.org/wiki/Public_holidays_in_Turkey
@@ -111,17 +117,17 @@ tests:
     expect:
       name: "Cumhuriyet Bayramı"
   - given:
-      date: ['2017-6-25', '2018-6-15', '2019-6-4', '2020-5-24', '2021-5-13', '2022-5-2', '2023-4-21', '2024-4-10', '2025-3-30', '2026-3-20', '2027-3-9', '2028-2-26', '2029-2-15', '2030-2-4']
+      date: ['2017-6-25', '2018-6-15', '2019-6-4', '2020-5-24', '2021-5-13', '2022-5-2', '2023-4-21', '2024-4-10', '2025-3-30', '2026-3-20', '2027-3-9', '2028-2-26', '2029-2-15', '2030-2-4', '2031-1-25', '2032-1-14']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı"
   - given:
-      date: ['2017-6-26', '2018-6-16', '2019-6-5', '2020-5-25', '2021-5-14', '2022-5-3', '2023-4-22', '2024-4-11', '2025-3-31', '2026-3-21', '2027-3-10', '2028-2-27', '2029-2-16', '2030-2-5']
+      date: ['2017-6-26', '2018-6-16', '2019-6-5', '2020-5-25', '2021-5-14', '2022-5-3', '2023-4-22', '2024-4-11', '2025-3-31', '2026-3-21', '2027-3-10', '2028-2-27', '2029-2-16', '2030-2-5', '2031-1-26', '2032-1-15']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-6-27', '2018-6-17', '2019-6-6', '2020-5-26', '2021-5-15', '2022-5-4', '2023-4-23', '2024-4-12', '2025-4-1', '2026-3-22', '2027-3-11', '2028-2-28', '2029-2-17', '2030-2-6']
+      date: ['2017-6-27', '2018-6-17', '2019-6-6', '2020-5-26', '2021-5-15', '2022-5-4', '2023-4-23', '2024-4-12', '2025-4-1', '2026-3-22', '2027-3-11', '2028-2-28', '2029-2-17', '2030-2-6', '2031-1-27', '2032-1-16']
       regions: ["tr"]
     expect:
       name: "Ramazan Bayramı (üçüncü tatil)"
@@ -131,22 +137,22 @@ tests:
     expect:
       name: "Demokrasi ve Milli Birlik Günü"
   - given:
-      date: ['2017-9-1', '2018-8-21', '2019-8-11', '2020-7-31', '2021-7-20', '2022-7-9', '2023-6-28', '2024-6-16', '2025-6-6', '2026-5-27', '2027-5-16', '2028-5-5', '2029-4-24', '2030-4-13']
+      date: ['2017-9-1', '2018-8-21', '2019-8-11', '2020-7-31', '2021-7-20', '2022-7-9', '2023-6-28', '2024-6-16', '2025-6-6', '2026-5-27', '2027-5-16', '2028-5-5', '2029-4-24', '2030-4-13', '2031-4-3', '2032-3-22']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı"
   - given:
-      date: ['2017-9-2', '2018-8-22', '2019-8-12', '2020-8-01', '2021-7-21', '2022-7-10', '2023-6-29', '2024-6-17', '2025-6-7', '2026-5-28', '2027-5-17', '2028-5-6', '2029-4-25', '2030-4-14']
+      date: ['2017-9-2', '2018-8-22', '2019-8-12', '2020-8-01', '2021-7-21', '2022-7-10', '2023-6-29', '2024-6-17', '2025-6-7', '2026-5-28', '2027-5-17', '2028-5-6', '2029-4-25', '2030-4-14', '2031-4-4', '2032-3-23']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (ikinci tatil)"
   - given:
-      date: ['2017-9-3', '2018-8-23', '2019-8-13', '2020-8-02', '2021-7-22', '2022-7-11', '2023-6-30', '2024-6-18', '2025-6-8', '2026-5-29', '2027-5-18', '2028-5-7', '2029-4-26', '2030-4-15']
+      date: ['2017-9-3', '2018-8-23', '2019-8-13', '2020-8-02', '2021-7-22', '2022-7-11', '2023-6-30', '2024-6-18', '2025-6-8', '2026-5-29', '2027-5-18', '2028-5-7', '2029-4-26', '2030-4-15', '2031-4-5', '2032-3-24']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (üçüncü tatil)"
   - given:
-      date: ['2017-9-4', '2018-8-24', '2019-8-14', '2020-8-03', '2021-7-23', '2022-7-12', '2023-7-1', '2024-6-19', '2025-6-9', '2026-5-30', '2027-5-19', '2028-5-8', '2029-4-27', '2030-4-16']
+      date: ['2017-9-4', '2018-8-24', '2019-8-14', '2020-8-03', '2021-7-23', '2022-7-12', '2023-7-1', '2024-6-19', '2025-6-9', '2026-5-30', '2027-5-19', '2028-5-8', '2029-4-27', '2030-4-16', '2031-4-6', '2032-3-25']
       regions: ["tr"]
     expect:
       name: "Kurban Bayramı (dördüncü tatil)"


### PR DESCRIPTION
Replaces the hand-maintained per-year date table for tr Ramazan and Kurban Bayramı with a tabular Hijri calendar calculation in the consuming library, plus a per-year override for the years Türkiye's Diyanet proclamation differs from the arithmetic. Outside the old table's range both holidays silently disappeared; that failure mode is the point of #377.

This is the definitions-side prep: the header note now describes the calculated approach and the tests cover 2031 and 2032, beyond the old table. The ramadan_feast / sacrifice_feast implementation change lands in holidays/holidays and the new tests run there via rake generate.

Closes #377 once the gem release ships.