### PR TITLE
Shift observed Independence Day off weekends for all US regions

### DIFF
--- a/us.yaml
+++ b/us.yaml
@@ -281,10 +281,7 @@ months:
   - name: Independence Day # fixed
     regions: [us]
     mday: 4
-  - name: Independence Day (Holiday)
-    regions: [us_va]
-    mday: 4
-    function: to_weekday_if_weekend(date) # Note: Always if Independence Day don't match
+    observed: independence_day(region, date)
   - name: Pioneer Day # fixed
     regions: [us_ut]
     mday: 24
@@ -780,7 +777,31 @@ tests:
       date: ['2020-7-3', '2021-7-5', '2026-7-3']
       regions: ["us_va"]
     expect:
-      name: "Independence Day (Holiday)"
+      holiday: false
+  - given:
+      date: ['2026-7-4', '2027-7-4']
+      regions: ["us", "us_ri"]
+      options: ["observed"]
+    expect:
+      holiday: false
+  - given:
+      date: ['2026-7-3', '2027-7-5']
+      regions: ["us", "us_va"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: ['2026-7-6']
+      regions: ["us_ri"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
+  - given:
+      date: ['2026-7-4']
+      regions: ["us_tx"]
+      options: ["observed"]
+    expect:
+      name: "Independence Day"
   - given:
       date: ['2020-7-24']
       regions: ["us_ut"]


### PR DESCRIPTION
The definitions side of holidays/holidays#478. `Holidays.on(July 4, :us, :observed)` returned the raw weekend date everywhere except Virginia.

This adds `observed: independence_day(region, date)` to the federal Independence Day entry and removes the separate Virginia-only `to_weekday_if_weekend` shim, so every US region gets the correct observed date: nearest weekday for most, the following Monday for Rhode Island, no shift for Texas. Depends on the companion gem PR that implements the `independence_day` custom method.
